### PR TITLE
Task/add multiple relationships logic

### DIFF
--- a/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -260,11 +260,12 @@ class DataCatalogFacade:
             tag_to_create = tag
             tag_to_update = None
             for persisted_tag in persisted_tags:
-                if tag.template == persisted_tag.template:
+                if tag.template == persisted_tag.template and tag.column == persisted_tag.column:
                     tag_to_create = None
                     tag.name = persisted_tag.name
                     if not self.__tags_fields_are_equal(tag, persisted_tag):
                         tag_to_update = tag
+                    break
 
             if tag_to_create:
                 created_tag = self.create_tag(entry.name, tag_to_create)

--- a/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -260,7 +260,9 @@ class DataCatalogFacade:
             tag_to_create = tag
             tag_to_update = None
             for persisted_tag in persisted_tags:
-                if tag.template == persisted_tag.template and tag.column == persisted_tag.column:
+                if tag.template == persisted_tag.template and \
+                   tag.column == persisted_tag.column:
+
                     tag_to_create = None
                     tag.name = persisted_tag.name
                     if not self.__tags_fields_are_equal(tag, persisted_tag):

--- a/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper.py
+++ b/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper.py
@@ -63,8 +63,8 @@ class BaseEntryRelationshipMapper(ABC):
     def _map_related_entry(cls, assembled_entry_data, related_asset_type,
                            source_field_id, target_field_id, id_name_pairs):
 
-        relationship_tag = None
-        related_asset_id = None
+        relationship_tag_dict = {}
+        related_asset_ids = []
         tags = assembled_entry_data.tags
         if not tags:
             return
@@ -72,20 +72,22 @@ class BaseEntryRelationshipMapper(ABC):
         for tag in tags:
             if source_field_id not in tag.fields:
                 continue
-            relationship_tag = tag
             source_field = tag.fields[source_field_id]
             related_asset_id = source_field.string_value \
                 if source_field.string_value \
                 else int(source_field.double_value)
-        if related_asset_id is None:
-            return
+            related_asset_ids.append(related_asset_id)
+            relationship_tag_dict[related_asset_id] = tag
 
-        related_asset_key = '{}-{}'.format(related_asset_type,
-                                           related_asset_id)
-        if related_asset_key in id_name_pairs:
-            relationship_tag.fields[target_field_id].string_value = \
-                cls.__format_related_entry_url(
-                    id_name_pairs[related_asset_key])
+        if related_asset_ids:
+            for related_asset_id in related_asset_ids:
+                related_asset_key = '{}-{}'.format(related_asset_type,
+                                                   related_asset_id)
+                if related_asset_key in id_name_pairs:
+                    relationship_tag = relationship_tag_dict[related_asset_id]
+                    relationship_tag.fields[target_field_id].string_value = \
+                        cls.__format_related_entry_url(
+                            id_name_pairs[related_asset_key])
 
     @classmethod
     def __format_related_entry_url(cls, entry_name):


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Improved the create links relationships logic, that was initially created to the looker connector, to support multiple relationships on columns.

On testing this discovered a bug on the update Tag logic, when multiple columns had the same Template, and their Tags were updated, the update logic would pick the wrong tag, and add inconsistent info to Data Catalog. Fixes #8 

**- How I did it**
Improved the links relationships logic on: base_entry_relationship_mapper.py

**- How to verify it**
Use base_entry_relationship_mapper.py to create links at the Entry Columns level.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

