### PR TITLE
Task/add managed template option

### DIFF
--- a/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -98,11 +98,16 @@ class DataCatalogMetadataIngestor:
             logging.info('Starting the upsert tags step')
             self.__datacatalog_facade.upsert_tags(entry,
                                                   assembled_entry_data.tags)
-            if config:
-                delete_tags = config.get('delete_tags')
-                if delete_tags:
-                    logging.info('')
-                    logging.info('Starting the delete tags step')
-                    self.__datacatalog_facade.delete_tags(
-                        entry, assembled_entry_data.tags,
-                        self.__entry_group_id)
+            if config and 'delete_tags' in config:
+                delete_tags = config['delete_tags']
+                logging.info('')
+                logging.info('Starting the delete tags step')
+                # If not specified uses the entry group id to find
+                # what tag templates should have their tags deleted.
+                managed_tag_template = delete_tags.get('managed_tag_template')
+                if not managed_tag_template:
+                    managed_tag_template = self.__entry_group_id
+
+                self.__datacatalog_facade.delete_tags(
+                    entry, assembled_entry_data.tags,
+                    managed_tag_template)

--- a/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -109,5 +109,4 @@ class DataCatalogMetadataIngestor:
                     managed_tag_template = self.__entry_group_id
 
                 self.__datacatalog_facade.delete_tags(
-                    entry, assembled_entry_data.tags,
-                    managed_tag_template)
+                    entry, assembled_entry_data.tags, managed_tag_template)

--- a/datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
+++ b/datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
@@ -37,7 +37,7 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
     def setUp(self, mock_datacatalog_facade):
         self.__metadata_ingestor = ingest \
             .DataCatalogMetadataIngestor(
-            'project-id', 'location-id', 'entry_group_id')
+                'project-id', 'location-id', 'entry_group_id')
         # Shortcut for the object assigned
         # to self.__metadata_ingestor.__datacatalog_facade
         self.__datacatalog_facade = mock_datacatalog_facade.return_value
@@ -54,7 +54,8 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
 
-    def test_ingest_metadata_with_delete_tags_managed_template_config_should_succeed(self):
+    def test_ingest_metadata_with_delete_tags_managed_template_config_should_succeed(  # noqa:E501
+            self):
         entries = utils \
             .Utils.create_assembled_entries_user_defined_types()
 
@@ -63,9 +64,8 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
 
         expected_tag_template_arg = 'entry_group_id'
 
-        self.__metadata_ingestor.ingest_metadata(
-            entries, {},
-            {'delete_tags': {}})
+        self.__metadata_ingestor.ingest_metadata(entries, {},
+                                                 {'delete_tags': {}})
 
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
@@ -87,10 +87,11 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
 
         expected_tag_template_arg = 'my-template'
 
-        self.__metadata_ingestor.ingest_metadata(
-            entries, {},
-            {'delete_tags': {
-                'managed_tag_template': expected_tag_template_arg}})
+        self.__metadata_ingestor.ingest_metadata(entries, {}, {
+            'delete_tags': {
+                'managed_tag_template': expected_tag_template_arg
+            }
+        })
 
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Add a config option to the delete tags flow, to allow connectors to specify which is their tag template syntax. That way user applied tags won't be affected by the delete tags flow.

Only connectors that sync tags from the source system need this flow.

**- How I did it**
Added a config option to the the delete_tags_dict. The template value is checked on the delete tags flow.

**- How to verify it**
Tag an entry managed by the connector with a user defined tag template, then run the connector, the user defined tag won't be affected.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Config option to the tag delete flow, to allow users to specify the managed connector template.

