### PR TITLE
Fix the name of the test case for _format_id()

### DIFF
--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -25,7 +25,7 @@ class BaseEntryFactoryTestCase(unittest.TestCase):
     def setUp(self):
         self.__base_entry_factory = prepare.BaseEntryFactory()
 
-    def test_format_display_name_should_normalize_non_compliant_id(self):
+    def test_format_id_should_normalize_non_compliant_id(self):
         formatted_id = self.__base_entry_factory._format_id(u'ã123 - b456  ')
         self.assertEqual('a123_b456', formatted_id)
 


### PR DESCRIPTION
**- What I did**
Fixed the name of the test case for `_format_id()`.

**- How I did it**
Renaming the method from to `test_format_display_name_should_normalize_non_compliant_id` to `test_format_id_should_normalize_non_compliant_id`. 

**- How to verify it**
Running the unit tests: `python setup.py test`.

**- Description for the changelog**
Fix the name of the test case for _format_id().
