### PR TITLE
FIX set datacatalog client major version

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.5.0',
+    version='0.5.1',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=('google-cloud-monitoring', 'python-dateutil',
-                      'google-cloud-datacatalog'),
+                      'google-cloud-datacatalog>=1,<2'),
     setup_requires=('pytest-runner',),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',
                    'google-datacatalog-connectors-commons-test'),


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added enforcement for datacatalog client major version.

**- How I did it**
Changed setup.py file.

**- How to verify it**
Install the commons library.

**- Description for the changelog**
The datacatalog client library introduced a breaking change on version 2.0.0, so enforcing the commons library to use version lower than 2.
