### PR TITLE
ADD script to automatically create tags on connectors release process

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     namespace_packages=['google', 'google.datacatalog_connectors'],
     package_dir={'': 'src'},
     include_package_data=True,
-    install_requires=('google-cloud-monitoring', 'python-dateutil',
+    install_requires=('google-cloud-monitoring>=1,<2', 'python-dateutil',
                       'google-cloud-datacatalog>=1,<2'),
     setup_requires=('pytest-runner',),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',

--- a/tools/create-current-version-tags.sh
+++ b/tools/create-current-version-tags.sh
@@ -4,14 +4,13 @@ CURRENT_DIR=$(pwd)
 SETUP_FILENAME="setup.py"
 CONNECTOR_NAME_REGEXP="^google-datacatalog-connectors-([a-zA-Z-]+)$"
 
-release-create-tags::main(){
+create-current-version-tags::main(){
 
     if [[ -z "${GITHUB_TOKEN}" ]]; then
-        echo "Undefined GITHUB_TOKEN variable"
-        release-create-tags::usage
+        create-current-version-tags::usage
     fi
 
-    echo "START release tagging script"
+    echo "START current version tagging script"
     echo ""
 
     for connector_dir in `ls ${CURRENT_DIR} | grep connector`; do
@@ -19,14 +18,14 @@ release-create-tags::main(){
 
         setup_path=${CURRENT_DIR}/${connector_dir}/${SETUP_FILENAME}
 
-        release_version=$(sed -n "s/^ *version=['\'']//p" ${setup_path} | sed -n "s/['\'',]*$//p")
+        current_version=$(sed -n "s/^ *version=['\'']//p" ${setup_path} | sed -n "s/['\'',]*$//p")
 
         [[ ${connector_dir} =~ ${CONNECTOR_NAME_REGEXP} ]]
         connector_simple_name="${BASH_REMATCH[1]}"
 
-        echo " tagging ${connector_simple_name} with release version: ${release_version}"
+        echo " tagging ${connector_simple_name} with current version: ${current_version}"
 
-        tag_name="${connector_simple_name}-${release_version}"
+        tag_name="${connector_simple_name}-${current_version}"
 
         git tag ${tag_name}
 
@@ -44,12 +43,12 @@ release-create-tags::main(){
         echo ""
     done
 
-    echo 'END release tagging script'
+    echo 'END current version tagging script'
 }
 
-release-create-tags::usage(){
-  echo 'SET: "GITHUB_TOKEN" environment variable'
+create-current-version-tags::usage(){
+  echo 'Please set the "GITHUB_TOKEN" environment variable before running this script'
   exit 2
 }
 
-release-create-tags::main "$@"
+create-current-version-tags::main "$@"

--- a/tools/release-create-tags.sh
+++ b/tools/release-create-tags.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(pwd)
+SETUP_FILENAME="setup.py"
+CONNECTOR_NAME_REGEXP="^google-datacatalog-connectors-([a-zA-Z-]+)$"
+
+release-create-tags::main(){
+
+    if [[ -z "${GITHUB_TOKEN}" ]]; then
+        echo "Undefined GITHUB_TOKEN variable"
+        release-create-tags::usage
+    fi
+
+    echo "START release tagging script"
+    echo ""
+
+    for connector_dir in `ls ${CURRENT_DIR} | grep connector`; do
+        echo " running on: ${connector_dir}"
+
+        setup_path=${CURRENT_DIR}/${connector_dir}/${SETUP_FILENAME}
+
+        release_version=$(sed -n "s/^ *version=['\'']//p" ${setup_path} | sed -n "s/['\'',]*$//p")
+
+        [[ ${connector_dir} =~ ${CONNECTOR_NAME_REGEXP} ]]
+        connector_simple_name="${BASH_REMATCH[1]}"
+
+        echo " tagging ${connector_simple_name} with release version: ${release_version}"
+
+        tag_name="${connector_simple_name}-${release_version}"
+
+        git tag ${tag_name}
+
+        if [[ $? -eq 0 ]]
+            then
+                echo " tag: ${tag_name} created"
+                git_remote_url="$(git remote get-url origin).git"
+                git_auth_remote_url="${git_remote_url/github.com/${GITHUB_TOKEN}@github.com}"
+                git push ${git_auth_remote_url} ${tag_name}
+                echo " tag: ${tag_name} pushed!"
+            else
+                echo " tag: ${tag_name} failed!"
+        fi
+
+        echo ""
+    done
+
+    echo 'END release tagging script'
+}
+
+release-create-tags::usage(){
+  echo 'SET: "GITHUB_TOKEN" environment variable'
+  exit 2
+}
+
+release-create-tags::main "$@"


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added script to automatically create tags on release process.

**- How I did it**
Created the bash script `tools/release-create-tags.sh`.

**- How to verify it**
Run the release tagging step of the release process using the `tools/release-create-tags.sh` script. Afterwards verify the tags were created.

**- Description for the changelog**
Added script to automatically create tags on release process.

