### PR TITLE
UPDATE pandas version to be compatible with python3.7 and python3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 yapf
         pip install .
+        # Update the commons test library with the local version
+        pip install --upgrade ../google-datacatalog-connectors-commons-test
     - name: Formatting rules with yapf
       run: |
         # stop the build if formatting is different from yapf

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build-dir: ['./google-datacatalog-connectors-commons', './google-datacatalog-connectors-commons-test']
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
     defaults:
       run:
         working-directory: ${{ matrix.build-dir }}

--- a/google-datacatalog-connectors-commons-test/setup.py
+++ b/google-datacatalog-connectors-commons-test/setup.py
@@ -23,16 +23,17 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons-test',
-    version='0.5.0',
+    version='0.5.1',
     author='Google LLC',
     description='Common test resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),
     namespace_packages=['google', 'google.datacatalog_connectors'],
     package_dir={'': 'src'},
     include_package_data=True,
-    install_requires=('pandas==0.24.2',
+    install_requires=('pandas>=1.1.4,<1.2.0',
                       'google-datacatalog-connectors-commons'),
     setup_requires=('pytest-runner',),
+
     tests_require=(
         'mock==3.0.5',
         'pytest',

--- a/google-datacatalog-connectors-commons-test/setup.py
+++ b/google-datacatalog-connectors-commons-test/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons-test',
-    version='0.5.1',
+    version='0.5.0',
     author='Google LLC',
     description='Common test resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),

--- a/google-datacatalog-connectors-commons-test/setup.py
+++ b/google-datacatalog-connectors-commons-test/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons-test',
-    version='0.6.0',
+    version='0.7.0',
     author='Google LLC',
     description='Common test resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),

--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,14 +23,14 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.5.1',
+    version='0.5.2',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),
     namespace_packages=['google', 'google.datacatalog_connectors'],
     package_dir={'': 'src'},
     include_package_data=True,
-    install_requires=('google-cloud-monitoring', 'python-dateutil',
+    install_requires=('google-cloud-monitoring>=1,<2', 'python-dateutil',
                       'google-cloud-datacatalog>=1,<2'),
     setup_requires=('pytest-runner',),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',

--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.5.2',
+    version='0.5.1',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Fixed version on `setup.py` so it's using a version compatible with python3.8.

**- How I did it**
Fixed version on `setup.py` so it's using a version compatible with python3.8.

**- How to verify it**
Run the connector commons on a python3.7 or python3.8  env

**- Description for the changelog**
UPDATE pandas version to be compatible with python3.7 and python3.8

