### PR TITLE
Upgrade datacatalog client library version to 2.0.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,11 +10,12 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+
+  build-commons:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build-dir: ['./google-datacatalog-connectors-commons', './google-datacatalog-connectors-commons-test']
+        build-dir: ['./google-datacatalog-connectors-commons']
         python-version: [3.6, 3.7]
     defaults:
       run:
@@ -33,6 +34,40 @@ jobs:
         pip install .
         # Update the commons test library with the local version
         pip install --upgrade ../google-datacatalog-connectors-commons-test
+    - name: Formatting rules with yapf
+      run: |
+        # stop the build if formatting is different from yapf
+        yapf --diff --recursive src tests  
+    - name: Lint with flake8
+      run: |
+        flake8 src tests
+    - name: Test with pytest
+      run: |
+        python setup.py test
+
+  build-commons-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-dir: ['./google-datacatalog-connectors-commons-test']
+        python-version: [3.6, 3.7]
+    defaults:
+      run:
+        working-directory: ${{ matrix.build-dir }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 yapf
+        pip install .
+        # Update the connector commons library with the local version
+        pip install --upgrade ../google-datacatalog-connectors-commons
     - name: Formatting rules with yapf
       run: |
         # stop the build if formatting is different from yapf

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 yapf
         pip install .
+        # Update the commons test library with the local version
+        pip install --upgrade ../google-datacatalog-connectors-commons-test
     - name: Formatting rules with yapf
       run: |
         # stop the build if formatting is different from yapf

--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -16,7 +16,7 @@
 
 import setuptools
 
-release_status='Development Status :: 4 - Beta'
+release_status = 'Development Status :: 4 - Beta'
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=('google-cloud-monitoring>=1,<2', 'python-dateutil',
-                      'google-cloud-datacatalog>=1,<2'),
+                      'google-cloud-datacatalog>=2'),
     setup_requires=('pytest-runner',),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',
                    'google-datacatalog-connectors-commons-test'),

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -20,17 +20,15 @@ from google.datacatalog_connectors.commons import utils
 
 from google.api_core import exceptions
 from google.cloud import datacatalog
-from google.cloud.datacatalog import types
-from google.cloud.datacatalog import enums
 
 
 class DataCatalogFacade:
     """Wraps Data Catalog's API calls."""
 
-    __BOOL_TYPE = enums.FieldType.PrimitiveType.BOOL
-    __DOUBLE_TYPE = enums.FieldType.PrimitiveType.DOUBLE
-    __STRING_TYPE = enums.FieldType.PrimitiveType.STRING
-    __TIMESTAMP_TYPE = enums.FieldType.PrimitiveType.TIMESTAMP
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
     def __init__(self, project_id):
         self.__datacatalog = datacatalog.DataCatalogClient()
@@ -45,9 +43,11 @@ class DataCatalogFacade:
         :return: The created Entry.
         """
         try:
-            entry = self.__datacatalog.create_entry(parent=entry_group_name,
-                                                    entry_id=entry_id,
-                                                    entry=entry)
+            entry = self.__datacatalog.create_entry(request={
+                'parent': entry_group_name,
+                'entry_id': entry_id,
+                'entry': entry
+            })
             self.__log_entry_operation('created', entry=entry)
         except exceptions.PermissionDenied as e:
             entry_name = '{}/entries/{}'.format(entry_group_name, entry_id)
@@ -63,7 +63,7 @@ class DataCatalogFacade:
         :param name: The Entry name.
         :return: An Entry object if it exists.
         """
-        return self.__datacatalog.get_entry(name=name)
+        return self.__datacatalog.get_entry(request={'name': name})
 
     def update_entry(self, entry):
         """Updates an Entry.
@@ -71,7 +71,10 @@ class DataCatalogFacade:
         :param entry: An Entry object.
         :return: The updated Entry.
         """
-        entry = self.__datacatalog.update_entry(entry=entry, update_mask=None)
+        entry = self.__datacatalog.update_entry(request={
+            'entry': entry,
+            'update_mask': None
+        })
         self.__log_entry_operation('updated', entry=entry)
         return entry
 
@@ -88,10 +91,10 @@ class DataCatalogFacade:
         persisted_entry = entry
         entry_name = '{}/entries/{}'.format(entry_group_name, entry_id)
         try:
-            persisted_entry = self.get_entry(name=entry_name)
+            persisted_entry = self.get_entry(entry_name)
             self.__log_entry_operation('already exists', entry_name=entry_name)
             if self.__entry_was_updated(persisted_entry, entry):
-                persisted_entry = self.update_entry(entry=entry)
+                persisted_entry = self.update_entry(entry)
             else:
                 self.__log_entry_operation('is up-to-date',
                                            entry=persisted_entry)
@@ -112,9 +115,9 @@ class DataCatalogFacade:
         # Update time comparison allows to verify whether the entry was
         # updated on the source system.
         current_update_time = \
-            current_entry.source_system_timestamps.update_time.seconds
+            current_entry.source_system_timestamps.update_time.timestamp()
         new_update_time = \
-            new_entry.source_system_timestamps.update_time.seconds
+            new_entry.source_system_timestamps.update_time.timestamp()
 
         updated_time_changed = \
             new_update_time != 0 and current_update_time != new_update_time
@@ -146,7 +149,7 @@ class DataCatalogFacade:
         :param name: The Entry name.
         """
         try:
-            self.__datacatalog.delete_entry(name=name)
+            self.__datacatalog.delete_entry(request={'name': name})
             self.__log_entry_operation('deleted', entry_name=name)
         except Exception as e:
             logging.info(
@@ -173,10 +176,12 @@ class DataCatalogFacade:
         :return: The created Entry Group.
         """
         entry_group = self.__datacatalog.create_entry_group(
-            parent=datacatalog.DataCatalogClient.location_path(
-                self.__project_id, location_id),
-            entry_group_id=entry_group_id,
-            entry_group={})
+            request={
+                'parent': f'projects/{self.__project_id}'
+                          f'/locations/{location_id}',
+                'entry_group_id': entry_group_id,
+                'entry_group': {}
+            })
         logging.info('Entry Group created: %s', entry_group.name)
         return entry_group
 
@@ -186,7 +191,7 @@ class DataCatalogFacade:
 
         :param name: The Entry Group name.
         """
-        self.__datacatalog.delete_entry_group(name=name)
+        self.__datacatalog.delete_entry_group(request={'name': name})
 
     def create_tag_template(self, location_id, tag_template_id, tag_template):
         """Creates a Data Catalog Tag Template.
@@ -197,10 +202,12 @@ class DataCatalogFacade:
         :return: The created Tag Template.
         """
         created_tag_template = self.__datacatalog.create_tag_template(
-            parent=datacatalog.DataCatalogClient.location_path(
-                self.__project_id, location_id),
-            tag_template_id=tag_template_id,
-            tag_template=tag_template)
+            request={
+                'parent': f'projects/{self.__project_id}'
+                          f'/locations/{location_id}',
+                'tag_template_id': tag_template_id,
+                'tag_template': tag_template
+            })
 
         logging.info('Tag Template created: %s', created_tag_template.name)
         return created_tag_template
@@ -211,7 +218,7 @@ class DataCatalogFacade:
         :param name: The Tag Templane name.
         :return: A Tag Template object if it exists.
         """
-        return self.__datacatalog.get_tag_template(name=name)
+        return self.__datacatalog.get_tag_template(request={'name': name})
 
     def get_tag_field_values_for_search_results(self, query, template,
                                                 tag_field, tag_field_type):
@@ -251,7 +258,10 @@ class DataCatalogFacade:
 
         :param name: The Tag Template name.
         """
-        self.__datacatalog.delete_tag_template(name=name, force=True)
+        self.__datacatalog.delete_tag_template(request={
+            'name': name,
+            'force': True
+        })
         logging.info('Tag Template deleted: %s', name)
 
     def create_tag(self, entry_name, tag):
@@ -261,7 +271,10 @@ class DataCatalogFacade:
         :param tag: A Tag object.
         :return: The created Tag.
         """
-        return self.__datacatalog.create_tag(parent=entry_name, tag=tag)
+        return self.__datacatalog.create_tag(request={
+            'parent': entry_name,
+            'tag': tag
+        })
 
     def delete_tag(self, tag):
         """Deletes a Data Catalog Tag.
@@ -269,7 +282,7 @@ class DataCatalogFacade:
         :param tag: A Tag object.
         :return: The deleted Tag.
         """
-        return self.__datacatalog.delete_tag(tag.name)
+        return self.__datacatalog.delete_tag(request={'name': tag.name})
 
     def list_tags(self, entry_name):
         """List Tags for a given Entry.
@@ -277,7 +290,7 @@ class DataCatalogFacade:
         :param entry_name: The parent Entry name.
         :return: A list of Tag objects.
         """
-        return self.__datacatalog.list_tags(parent=entry_name)
+        return self.__datacatalog.list_tags(request={'parent': entry_name})
 
     def update_tag(self, tag):
         """Updates a Tag.
@@ -285,7 +298,10 @@ class DataCatalogFacade:
         :param tag: A Tag object.
         :return: The updated Tag.
         """
-        return self.__datacatalog.update_tag(tag=tag, update_mask=None)
+        return self.__datacatalog.update_tag(request={
+            'tag': tag,
+            'update_mask': None
+        })
 
     def upsert_tags(self, entry, tags):
         """Updates or creates Tag for a given Entry.
@@ -312,7 +328,7 @@ class DataCatalogFacade:
 
                     tag_to_create = None
                     tag.name = persisted_tag.name
-                    if not self.__tags_fields_are_equal(tag, persisted_tag):
+                    if not self.__tag_fields_are_equal(tag, persisted_tag):
                         tag_to_update = tag
                     break
 
@@ -359,7 +375,7 @@ class DataCatalogFacade:
                 logging.info('Tag is up-to-date: %s', persisted_tag.name)
 
     @classmethod
-    def __tags_fields_are_equal(cls, tag_1, tag_2):
+    def __tag_fields_are_equal(cls, tag_1, tag_2):
         for field_id in tag_1.fields:
             tag_1_field = tag_1.fields[field_id]
             tag_2_field = tag_2.fields[field_id]
@@ -371,8 +387,8 @@ class DataCatalogFacade:
             values_are_equal = values_are_equal \
                 and tag_1_field.string_value == tag_2_field.string_value
             values_are_equal = values_are_equal \
-                and tag_1_field.timestamp_value.seconds == \
-                tag_2_field.timestamp_value.seconds
+                and cls.__timestamp_tag_fields_are_equal(
+                    tag_1_field, tag_2_field)
             values_are_equal = values_are_equal \
                 and tag_1_field.enum_value.display_name == \
                 tag_2_field.enum_value.display_name
@@ -382,18 +398,31 @@ class DataCatalogFacade:
 
         return True
 
+    @classmethod
+    def __timestamp_tag_fields_are_equal(cls, tag_1_field, tag_2_field):
+        if not (tag_1_field.timestamp_value and tag_2_field.timestamp_value):
+            return True
+
+        return tag_1_field.timestamp_value.timestamp() == \
+            tag_2_field.timestamp_value.timestamp()
+
     def search_catalog(self, query):
         """Searches Data Catalog for a given query.
 
         :param query: The query string.
         :return: A Search Result list.
         """
-        scope = types.SearchCatalogRequest.Scope()
+        scope = datacatalog.SearchCatalogRequest.Scope()
         scope.include_project_ids.append(self.__project_id)
 
         return [
             result for result in self.__datacatalog.search_catalog(
-                scope=scope, query=query, order_by='relevance', page_size=1000)
+                request={
+                    'scope': scope,
+                    'query': query,
+                    'page_size': 'relevance',
+                    'page_token': 1000
+                })
         ]
 
     def search_catalog_relative_resource_name(self, query):
@@ -405,5 +434,5 @@ class DataCatalogFacade:
         """
         return [
             result.relative_resource_name
-            for result in self.search_catalog(query=query)
+            for result in self.search_catalog(query)
         ]

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper.py
@@ -16,6 +16,8 @@
 
 import abc
 
+from google.cloud import datacatalog
+
 ABC = abc.ABCMeta('ABC', (object,), {})  # compatible with Python 2 *and* 3
 
 
@@ -85,9 +87,10 @@ class BaseEntryRelationshipMapper(ABC):
                                                    related_asset_id)
                 if related_asset_key in id_name_pairs:
                     relationship_tag = relationship_tag_dict[related_asset_id]
-                    relationship_tag.fields[target_field_id].string_value = \
-                        cls.__format_related_entry_url(
-                            id_name_pairs[related_asset_key])
+                    string_field = datacatalog.TagField()
+                    string_field.string_value = cls.__format_related_entry_url(
+                        id_name_pairs[related_asset_key])
+                    relationship_tag.fields[target_field_id] = string_field
 
     @classmethod
     def __format_related_entry_url(cls, entry_name):

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_factory.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.cloud import datacatalog
+from google.protobuf import timestamp_pb2
 import six
 
 
@@ -26,12 +28,16 @@ class BaseTagFactory:
     @classmethod
     def _set_bool_field(cls, tag, field_id, value):
         if value is not None:
-            tag.fields[field_id].bool_value = value
+            bool_field = datacatalog.TagField()
+            bool_field.bool_value = value
+            tag.fields[field_id] = bool_field
 
     @classmethod
     def _set_double_field(cls, tag, field_id, value):
         if value:
-            tag.fields[field_id].double_value = value
+            double_field = datacatalog.TagField()
+            double_field.double_value = value
+            tag.fields[field_id] = double_field
 
     @classmethod
     def _set_string_field(cls, tag, field_id, value):
@@ -77,9 +83,16 @@ class BaseTagFactory:
                 'ignore')) if len(encoded) > max_length else encoded.decode(
                     encoding, 'ignore')
 
-        tag.fields[field_id].string_value = decoded
+        string_field = datacatalog.TagField()
+        string_field.string_value = decoded
+        tag.fields[field_id] = string_field
 
     @classmethod
     def _set_timestamp_field(cls, tag, field_id, value):
         if value:
-            tag.fields[field_id].timestamp_value.FromDatetime(value)
+            timestamp = timestamp_pb2.Timestamp()
+            timestamp.FromDatetime(value)
+
+            timestamp_field = datacatalog.TagField()
+            timestamp_field.timestamp_value = timestamp
+            tag.fields[field_id] = timestamp_field

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
@@ -18,17 +18,17 @@ import unittest
 
 import mock
 from google.api_core import exceptions
-from google.cloud.datacatalog import enums, types
+from google.cloud import datacatalog
 from google.datacatalog_connectors.commons_test import utils
 
 from google.datacatalog_connectors.commons import ingest
 
 
 class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
-    __BOOL_TYPE = enums.FieldType.PrimitiveType.BOOL
-    __DOUBLE_TYPE = enums.FieldType.PrimitiveType.DOUBLE
-    __STRING_TYPE = enums.FieldType.PrimitiveType.STRING
-    __TIMESTAMP_TYPE = enums.FieldType.PrimitiveType.TIMESTAMP
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
     __COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
 
@@ -153,7 +153,7 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
 
     @classmethod
     def __create_tag_template(cls):
-        template = types.TagTemplate()
+        template = datacatalog.TagTemplate()
 
         tag_template_id = 'template'
 
@@ -161,20 +161,26 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
 
         template.display_name = 'template display name'
 
-        template.fields['bool-field'].type.primitive_type = cls.__BOOL_TYPE
-        template.fields['bool-field'].display_name = 'Bool Field'
+        bool_field = datacatalog.TagTemplateField()
+        bool_field.type.primitive_type = cls.__BOOL_TYPE
+        template.fields['bool-field'] = bool_field
 
-        template.fields['double-field'].type.primitive_type = cls.__DOUBLE_TYPE
-        template.fields['double-field'].display_name = 'Double Field'
+        double_field = datacatalog.TagTemplateField()
+        double_field.type.primitive_type = cls.__DOUBLE_TYPE
+        template.fields['double-field'] = double_field
 
-        template.fields['string-field'].type.primitive_type = cls.__STRING_TYPE
-        template.fields['string-field'].display_name = 'String Field'
+        string_field = datacatalog.TagTemplateField()
+        string_field.type.primitive_type = cls.__STRING_TYPE
+        template.fields['string-field'] = string_field
 
-        template.fields['timestamp-field'].type.primitive_type = \
-            cls.__TIMESTAMP_TYPE
-        template.fields['timestamp-field'].display_name = 'Timestamp Field'
+        timestamp_field = datacatalog.TagTemplateField()
+        timestamp_field.type.primitive_type = cls.__TIMESTAMP_TYPE
+        template.fields['timestamp-field'] = timestamp_field
 
-        template.fields['enum-field'].type.enum_type.allowed_values \
-            .add().display_name = 'Test ENUM Value'
+        enum_value = datacatalog.FieldType.EnumType.EnumValue()
+        enum_value.display_name = 'Test ENUM Value'
+        enum_field = datacatalog.TagTemplateField()
+        enum_field.type.enum_type.allowed_values.append(enum_value)
+        template.fields['enum-field'] = enum_field
 
         return tag_template_id, template

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_relationship_mapper_test.py
@@ -17,7 +17,7 @@
 import unittest
 
 import mock
-from google.cloud.datacatalog import types
+from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import prepare
 
 
@@ -163,22 +163,26 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type):
-        entry = types.Entry()
+        entry = datacatalog.Entry()
         entry.name = 'fake_entries/{}'.format(entry_id)
         entry.user_specified_type = entry_type
         return entry
 
     @classmethod
     def __make_fake_tag(cls, string_fields=None, double_fields=None):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         if string_fields:
             for field in string_fields:
-                tag.fields[field[0]].string_value = field[1]
+                string_field = datacatalog.TagField()
+                string_field.string_value = field[1]
+                tag.fields[field[0]] = string_field
 
         if double_fields:
             for field in double_fields:
-                tag.fields[field[0]].double_value = field[1]
+                double_field = datacatalog.TagField()
+                double_field.double_value = field[1]
+                tag.fields[field[0]] = double_field
 
         return tag
 

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
@@ -21,7 +21,7 @@ import unittest
 from google.datacatalog_connectors.commons import prepare
 import dateutil.parser
 
-from google.cloud.datacatalog import types
+from google.cloud import datacatalog
 
 
 class BaseTagFactoryTestCase(unittest.TestCase):
@@ -30,37 +30,37 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         self.__base_tag_factory = prepare.BaseTagFactory()
 
     def test_set_bool_field_should_skip_none_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_bool_field(tag, 'bool', None)
 
         self.assertNotIn('bool', tag.fields)
 
     def test_set_bool_field_should_set_given_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_bool_field(tag, 'bool', False)
 
         self.assertFalse(tag.fields['bool'].bool_value)
 
     def test_set_double_field_should_skip_none_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_double_field(tag, 'double', None)
 
         self.assertNotIn('double', tag.fields)
 
     def test_set_double_field_should_set_given_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_double_field(tag, 'double', 2.5)
 
         self.assertEqual(2.5, tag.fields['double'].double_value)
 
     def test_set_string_field_should_skip_none_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_string_field(tag, 'string', None)
 
         self.assertNotIn('string', tag.fields)
 
     def test_set_string_field_should_skip_empty_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_string_field(tag, 'string', '')
 
         self.assertNotIn('string', tag.fields)
@@ -72,7 +72,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
          1 byte when encoded in UTF-8.
         """
 
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_string_field(tag, 'string', 'a' * 2001)
 
         self.assertEqual(2000, len(tag.fields['string'].string_value))
@@ -88,7 +88,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
          needs 2 bytes and periods need 1 byte when encoded in UTF-8.
         """
 
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         str_value = u''
         for _ in range(1010):
             str_value += u'ã'
@@ -114,7 +114,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
          encoded in UTF-8.
         """
 
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         str_value = u''
         for _ in range(10):
@@ -134,18 +134,19 @@ class BaseTagFactoryTestCase(unittest.TestCase):
             1999, len(tag.fields['string'].string_value.encode('UTF-8')))
 
     def test_set_timestamp_field_should_skip_none_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_timestamp_field(tag, 'timestamp-field',
                                                      None)
 
         self.assertNotIn('timestamp-field', tag.fields)
 
     def test_set_timestamp_field_should_set_given_value(self):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         self.__base_tag_factory._set_timestamp_field(
             tag, 'timestamp-field',
             dateutil.parser.isoparse('2019-09-12T16:30:00+0000'))
 
         date = dateutil.parser.isoparse('2019-09-12T16:30:00+0000')
-        self.assertEqual(int(calendar.timegm(date.utctimetuple())),
-                         tag.fields['timestamp-field'].timestamp_value.seconds)
+        self.assertEqual(
+            int(calendar.timegm(date.utctimetuple())),
+            tag.fields['timestamp-field'].timestamp_value.timestamp())


### PR DESCRIPTION
**- What I did**
Updated the code to make compatible with the Data Catalog client library v2.0.0

**- How I did it**
Followed the instructions from the [2.0.0 Migration Guide](https://github.com/googleapis/python-datacatalog/blob/master/UPGRADING.md) and other changes not covered in that guide.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Upgrade datacatalog client library version to 2.0.0

Closes #17 