### PR TITLE
FIX Tag field logic when double value was zero

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_factory.py
@@ -34,7 +34,7 @@ class BaseTagFactory:
 
     @classmethod
     def _set_double_field(cls, tag, field_id, value):
-        if value:
+        if value is not None:
             double_field = datacatalog.TagField()
             double_field.double_value = value
             tag.fields[field_id] = double_field

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
@@ -53,6 +53,12 @@ class BaseTagFactoryTestCase(unittest.TestCase):
 
         self.assertEqual(2.5, tag.fields['double'].double_value)
 
+    def test_set_double_zero_field_should_set_given_value(self):
+        tag = datacatalog.Tag()
+        self.__base_tag_factory._set_double_field(tag, 'double', 0)
+
+        self.assertEqual(0, tag.fields['double'].double_value) 
+
     def test_set_string_field_should_skip_none_value(self):
         tag = datacatalog.Tag()
         self.__base_tag_factory._set_string_field(tag, 'string', None)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
@@ -57,7 +57,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         tag = datacatalog.Tag()
         self.__base_tag_factory._set_double_field(tag, 'double', 0)
 
-        self.assertEqual(0, tag.fields['double'].double_value) 
+        self.assertEqual(0, tag.fields['double'].double_value)
 
     def test_set_string_field_should_skip_none_value(self):
         tag = datacatalog.Tag()


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
FIX Tag field logic when double value was zero

**- How I did it**
changed the way the double value is tested.

**- How to verify it**
use the `_set_double_field` method with zero value

**- Description for the changelog**
FIX Tag field logic when double value was zero

