### PR TITLE
FIX __entry_was_updated  method to handle none timestamp fields

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -109,10 +109,15 @@ class DataCatalogFacade:
     def __entry_was_updated(cls, current_entry, new_entry):
         # Update time comparison allows to verify whether the entry was
         # updated on the source system.
-        current_update_time = \
-            current_entry.source_system_timestamps.update_time.timestamp()
-        new_update_time = \
-            new_entry.source_system_timestamps.update_time.timestamp()
+        current_update_time = 0
+        if current_entry.source_system_timestamps.update_time:
+            current_update_time = \
+                current_entry.source_system_timestamps.update_time.timestamp()
+
+        new_update_time = 0
+        if new_entry.source_system_timestamps.update_time:        
+            new_update_time = \
+                new_entry.source_system_timestamps.update_time.timestamp()
 
         updated_time_changed = \
             new_update_time != 0 and current_update_time != new_update_time

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -115,7 +115,7 @@ class DataCatalogFacade:
                 current_entry.source_system_timestamps.update_time.timestamp()
 
         new_update_time = 0
-        if new_entry.source_system_timestamps.update_time:        
+        if new_entry.source_system_timestamps.update_time:
             new_update_time = \
                 new_entry.source_system_timestamps.update_time.timestamp()
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
added logic to handle none timestamp fields.

**- How I did it**
added logic to handle none timestamp fields.

**- How to verify it**
Run a RDBMS connector which does not have the timestamp fields.

**- Description for the changelog**
FIX `__entry_was_updated` method to handle none timestamp fields

