### PR TITLE
Create the BaseTagTemplateFactory class

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/__init__.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/__init__.py
@@ -18,6 +18,8 @@ from .assembled_entry_data import AssembledEntryData
 from .base_entry_factory import BaseEntryFactory
 from .base_entry_relationship_mapper import BaseEntryRelationshipMapper
 from .base_tag_factory import BaseTagFactory
+from .base_tag_template_factory import BaseTagTemplateFactory
 
 __all__ = ('AssembledEntryData', 'BaseEntryFactory',
-           'BaseEntryRelationshipMapper', 'BaseTagFactory')
+           'BaseEntryRelationshipMapper', 'BaseTagFactory',
+           'BaseTagTemplateFactory')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_template_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_template_factory.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud import datacatalog
+
+
+class BaseTagTemplateFactory:
+
+    @classmethod
+    def _add_enum_type_field(cls, tag_template, field_id, values,
+                             display_name):
+
+        field = datacatalog.TagTemplateField()
+        for value in values:
+            enum_value = datacatalog.FieldType.EnumType.EnumValue()
+            enum_value.display_name = value
+            field.type.enum_type.allowed_values.append(enum_value)
+
+        field.display_name = display_name
+        tag_template.fields[field_id] = field
+
+    @classmethod
+    def _add_primitive_type_field(cls, tag_template, field_id, field_type,
+                                  display_name):
+
+        field = datacatalog.TagTemplateField()
+        field.type.primitive_type = field_type
+        field.display_name = display_name
+        tag_template.fields[field_id] = field

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -22,14 +22,11 @@ from google.datacatalog_connectors.commons import prepare
 
 class BaseEntryFactoryTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.__base_entry_factory = prepare.BaseEntryFactory()
-
     def test_format_id_should_normalize_non_compliant_id(self):
-        formatted_id = self.__base_entry_factory._format_id(u'ã123 - b456  ')
+        formatted_id = prepare.BaseEntryFactory._format_id(u'ã123 - b456  ')
         self.assertEqual('a123_b456', formatted_id)
 
     def test_format_display_name_should_normalize_non_compliant_name(self):
-        formatted_name = self.__base_entry_factory._format_display_name(
+        formatted_name = prepare.BaseEntryFactory._format_display_name(
             u'ã123 :?: b456  ')
         self.assertEqual('a123 _ b456', formatted_name)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_factory_test.py
@@ -26,48 +26,45 @@ from google.cloud import datacatalog
 
 class BaseTagFactoryTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.__base_tag_factory = prepare.BaseTagFactory()
-
     def test_set_bool_field_should_skip_none_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_bool_field(tag, 'bool', None)
+        prepare.BaseTagFactory._set_bool_field(tag, 'bool', None)
 
         self.assertNotIn('bool', tag.fields)
 
     def test_set_bool_field_should_set_given_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_bool_field(tag, 'bool', False)
+        prepare.BaseTagFactory._set_bool_field(tag, 'bool', False)
 
         self.assertFalse(tag.fields['bool'].bool_value)
 
     def test_set_double_field_should_skip_none_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_double_field(tag, 'double', None)
+        prepare.BaseTagFactory._set_double_field(tag, 'double', None)
 
         self.assertNotIn('double', tag.fields)
 
     def test_set_double_field_should_set_given_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_double_field(tag, 'double', 2.5)
+        prepare.BaseTagFactory._set_double_field(tag, 'double', 2.5)
 
         self.assertEqual(2.5, tag.fields['double'].double_value)
 
     def test_set_double_zero_field_should_set_given_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_double_field(tag, 'double', 0)
+        prepare.BaseTagFactory._set_double_field(tag, 'double', 0)
 
         self.assertEqual(0, tag.fields['double'].double_value)
 
     def test_set_string_field_should_skip_none_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_string_field(tag, 'string', None)
+        prepare.BaseTagFactory._set_string_field(tag, 'string', None)
 
         self.assertNotIn('string', tag.fields)
 
     def test_set_string_field_should_skip_empty_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_string_field(tag, 'string', '')
+        prepare.BaseTagFactory._set_string_field(tag, 'string', '')
 
         self.assertNotIn('string', tag.fields)
 
@@ -79,7 +76,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         """
 
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_string_field(tag, 'string', 'a' * 2001)
+        prepare.BaseTagFactory._set_string_field(tag, 'string', 'a' * 2001)
 
         self.assertEqual(2000, len(tag.fields['string'].string_value))
         self.assertEqual('{}...'.format('a' * 1997),
@@ -99,7 +96,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         for _ in range(1010):
             str_value += u'ã'
 
-        self.__base_tag_factory._set_string_field(tag, 'string', str_value)
+        prepare.BaseTagFactory._set_string_field(tag, 'string', str_value)
 
         self.assertEqual(1001, len(tag.fields['string'].string_value))
 
@@ -126,7 +123,7 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         for _ in range(10):
             str_value += u'ã'
 
-        self.__base_tag_factory._set_string_field(
+        prepare.BaseTagFactory._set_string_field(
             tag, 'string', u'{}{}'.format('a' * 1990, str_value))
 
         str_value = u''
@@ -141,14 +138,14 @@ class BaseTagFactoryTestCase(unittest.TestCase):
 
     def test_set_timestamp_field_should_skip_none_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_timestamp_field(tag, 'timestamp-field',
-                                                     None)
+        prepare.BaseTagFactory._set_timestamp_field(tag, 'timestamp-field',
+                                                    None)
 
         self.assertNotIn('timestamp-field', tag.fields)
 
     def test_set_timestamp_field_should_set_given_value(self):
         tag = datacatalog.Tag()
-        self.__base_tag_factory._set_timestamp_field(
+        prepare.BaseTagFactory._set_timestamp_field(
             tag, 'timestamp-field',
             dateutil.parser.isoparse('2019-09-12T16:30:00+0000'))
 

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_template_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_template_factory_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# coding=utf-8
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.datacatalog_connectors.commons import prepare
+
+from google.cloud import datacatalog
+
+
+class BaseTagFactoryTestCase(unittest.TestCase):
+
+    def test_add_enum_type_field_should_set_elementary_properties(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_enum_type_field(
+            tag_template, 'enum-field', ['VALUE_1', 'VALUE_2'], 'Enum field')
+
+        self.assertIn('enum-field', tag_template.fields)
+
+        field = tag_template.fields['enum-field']
+        self.assertEqual(2, len(field.type.enum_type.allowed_values))
+        self.assertEqual('Enum field', field.display_name)
+
+    def test_add_primitive_type_field_should_set_elementary_properties(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_primitive_type_field(
+            tag_template, 'string-field',
+            datacatalog.FieldType.PrimitiveType.STRING, 'String field')
+
+        self.assertIn('string-field', tag_template.fields)
+
+        field = tag_template.fields['string-field']
+        self.assertEqual(datacatalog.FieldType.PrimitiveType.STRING,
+                         field.type.primitive_type)
+        self.assertEqual('String field', field.display_name)


### PR DESCRIPTION
**- What I did**
Created a parent class to share helper code with all Tag Template factories.

**- How I did it**
Created the `BaseTagTemplateFactory` class in `google.datacatalog_connectors.commons.prepare`.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added the BaseTagTemplateFactory class

