### PR TITLE
Fix scenario when columns are created with uppercased names

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.6.1',
+    version='0.6.2',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -308,8 +308,9 @@ class DataCatalogFacade:
             tag_to_create = tag
             tag_to_update = None
             for persisted_tag in persisted_tags:
+                # column name is case insensitive.
                 if tag.template == persisted_tag.template and \
-                   tag.column == persisted_tag.column:
+                   tag.column.lower() == persisted_tag.column.lower():
 
                     tag_to_create = None
                     tag.name = persisted_tag.name

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -308,7 +308,7 @@ class DataCatalogFacade:
             tag_to_create = tag
             tag_to_update = None
             for persisted_tag in persisted_tags:
-                # column name is case insensitive.
+                # The column field is not case sensitive.
                 if tag.template == persisted_tag.template and \
                    tag.column.lower() == persisted_tag.column.lower():
 

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -278,7 +278,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         datacatalog_client.create_tag.assert_not_called()
         self.assertEqual(1, datacatalog_client.update_tag.call_count)
 
-    def test_upsert_column_tags_unchanged_should_succeed(self):
+    def test_upsert_tags_unchanged_column_uppercase_should_succeed(self):
         entry = utils.Utils.create_entry_user_defined_type(
             'type', 'system', 'display_name', 'name', 'description',
             'linked_resource', 11, 22)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -257,6 +257,47 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         datacatalog_client.create_tag.assert_not_called()
         self.assertEqual(1, datacatalog_client.update_tag.call_count)
 
+    def test_upsert_columntags_changed_should_succeed(self):
+        datacatalog_client = self.__datacatalog_client
+
+        current_tag = self.__create_tag()
+        current_tag.column = 'ABC'
+
+        datacatalog_client.list_tags.return_value = [current_tag]
+
+        entry = utils.Utils.create_entry_user_defined_type(
+            'type', 'system', 'display_name', 'name', 'description',
+            'linked_resource', 11, 22)
+
+        changed_tag = self.__create_tag()
+        changed_tag.column = 'abc'
+        changed_tag.fields['bool-field'].bool_value = False
+
+        self.__datacatalog_facade.upsert_tags(entry, [changed_tag])
+
+        datacatalog_client.create_tag.assert_not_called()
+        self.assertEqual(1, datacatalog_client.update_tag.call_count)
+
+    def test_upsert_column_tags_unchanged_should_succeed(self):
+        entry = utils.Utils.create_entry_user_defined_type(
+            'type', 'system', 'display_name', 'name', 'description',
+            'linked_resource', 11, 22)
+
+        current_tag = self.__create_tag()
+        current_tag.column = 'ABC'
+
+        datacatalog_client = self.__datacatalog_client
+        datacatalog_client.list_tags.return_value = [current_tag]
+
+        # column name is case insensitive, so it's the same column.
+        tag = self.__create_tag()
+        tag.column = 'abc'
+
+        self.__datacatalog_facade.upsert_tags(entry, [tag])
+
+        datacatalog_client.create_tag.assert_not_called()
+        datacatalog_client.update_tag.assert_not_called()
+
     def test_upsert_tags_unchanged_should_succeed(self):
         entry = utils.Utils.create_entry_user_defined_type(
             'type', 'system', 'display_name', 'name', 'description',

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -257,7 +257,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         datacatalog_client.create_tag.assert_not_called()
         self.assertEqual(1, datacatalog_client.update_tag.call_count)
 
-    def test_upsert_columntags_changed_should_succeed(self):
+    def test_upsert_tags_changed_column_uppercase_should_succeed(self):
         datacatalog_client = self.__datacatalog_client
 
         current_tag = self.__create_tag()


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Changed tag column comparison to ignore case.

**- How I did it**
Changed tag column comparison to ignore case.

**- How to verify it**
Run a SQL connector which returns uppercased column names.

**- Description for the changelog**
Data Catalog entry columns names are case insensitive, so we need to ignore case.

