### PR TITLE
FIX set version of google datacatalog library to lower than v3.0.0

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.6.2',
+    version='0.6.3',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=('google-cloud-monitoring>=1,<2', 'python-dateutil',
-                      'google-cloud-datacatalog>=2'),
+                      'google-cloud-datacatalog>=2,<3'),
     setup_requires=('pytest-runner',),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',
                    'google-datacatalog-connectors-commons-test>=0.6.0'),


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Fixed the DC library version to be lower than 3.0.0 on `setup.py`

**- How I did it**
Fixed the DC library version to be lower than 3.0.0 on `setup.py`

**- How to verify it**
Run any connector tests.

**- Description for the changelog**
Google Data Catalog library has some breaking changes to the connectors on the version 3.0.0, this is breaking the hive connector: https://github.com/GoogleCloudPlatform/datacatalog-connectors-hive/issues/20 and most likely the other connectors.

