### PR TITLE
Add code to handle pre condition error on create_entry logic

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -50,12 +50,12 @@ class DataCatalogFacade:
                                                     entry_id=entry_id,
                                                     entry=entry)
             self.__log_entry_operation('created', entry=entry)
-        except exceptions.PermissionDenied as e:
+        except exceptions.FailedPrecondition as e:
             entry_name = '{}/entries/{}'.format(entry_group_name, entry_id)
             self.__log_entry_operation('was not created',
                                        entry_name=entry_name)
             logging.warning('Error: %s', e)
-        except exceptions.FailedPrecondition as e:
+        except exceptions.PermissionDenied as e:
             entry_name = '{}/entries/{}'.format(entry_group_name, entry_id)
             self.__log_entry_operation('was not created',
                                        entry_name=entry_name)

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -52,6 +52,11 @@ class DataCatalogFacade:
             self.__log_entry_operation('was not created',
                                        entry_name=entry_name)
             logging.warning('Error: %s', e)
+        except exceptions.FailedPrecondition as e:
+            entry_name = '{}/entries/{}'.format(entry_group_name, entry_id)
+            self.__log_entry_operation('was not created',
+                                       entry_name=entry_name)
+            logging.warning('Error: %s', e)
 
         return entry
 

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -105,7 +105,8 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
 
-    def test_upsert_entry_nonexistent_on_failed_precondition_should_not_raise(self):
+    def test_upsert_entry_nonexistent_on_failed_precondition_should_not_raise(
+            self):
         datacatalog_client = self.__datacatalog_client
         datacatalog_client.get_entry.side_effect = \
             exceptions.PermissionDenied('Entry not found')

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -105,6 +105,24 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
 
+    def test_upsert_entry_nonexistent_on_failed_precondition_should_not_raise(self):
+        datacatalog_client = self.__datacatalog_client
+        datacatalog_client.get_entry.side_effect = \
+            exceptions.PermissionDenied('Entry not found')
+
+        datacatalog_client.create_entry.side_effect = \
+            exceptions.FailedPrecondition('Failed precondition')
+
+        entry = utils.Utils.create_entry_user_defined_type(
+            'type', 'system', 'display_name', 'name', 'description',
+            'linked_resource', 11, 22)
+
+        self.__datacatalog_facade.upsert_entry('entry_group_name', 'entry_id',
+                                               entry)
+
+        self.assertEqual(1, datacatalog_client.get_entry.call_count)
+        self.assertEqual(1, datacatalog_client.create_entry.call_count)
+
     def test_upsert_entry_changed_should_update(self):
         entry_1 = utils.Utils.create_entry_user_defined_type(
             'type', 'system', 'display_name', 'name', 'description',

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -107,6 +107,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
 
     def test_upsert_entry_nonexistent_on_failed_precondition_should_not_raise(
             self):
+
         datacatalog_client = self.__datacatalog_client
         datacatalog_client.get_entry.side_effect = \
             exceptions.PermissionDenied('Entry not found')


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added an `except` clause to handle the `FailedPrecondition` exception. If this happens the entry is not ingested, a warning is logged and the connector goes to the next entry.

**- How I did it**
Added an `except` clause to handle the `FailedPrecondition` exception.

**- How to verify it**
1. Run a connector that ingests a large number of entries 10.000+
2. Clean up the ingested entries
3. Run the connector again in a short time span, like 1 hour from the first run.

This scenario should not break the connector now with this change.

**- Description for the changelog**
Fixes #37. 

There is also an open issue related to this: https://issuetracker.google.com/issues/170052119. So this PR proposes to ignore the error and skip the entry ingestion. As described in the open issue this a flaky error that is hard to reproduce, but with large numbers of entries this seem to be more common to reproduce.

