### PR TITLE
ADD new method to format entry id with hashing

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -16,8 +16,8 @@
 
 import hashlib
 import re
-import unicodedata
 import six
+import unicodedata
 
 
 class BaseEntryFactory:
@@ -26,16 +26,14 @@ class BaseEntryFactory:
 
     @classmethod
     def _format_id(cls, source_id):
-        formatted_id = cls.__format_and_normalize_str(r'[^a-zA-Z0-9]+',
-                                                      source_id)
+        formatted_id = cls.__normalize_string(r'[^a-zA-Z0-9]+', source_id)
 
         return formatted_id[:cls.__ID_MAX_LENGTH] if \
             len(formatted_id) > cls.__ID_MAX_LENGTH else formatted_id
 
     @classmethod
-    def _format_id_with_hashing(cls, source_id, length_to_hash):
-        formatted_id = cls.__format_and_normalize_str(r'[^a-zA-Z0-9]+',
-                                                      source_id)
+    def _format_id_with_hashing(cls, source_id, hash_length):
+        formatted_id = cls.__normalize_string(r'[^a-zA-Z0-9]+', source_id)
 
         if len(formatted_id) <= cls.__ID_MAX_LENGTH:
             return formatted_id
@@ -43,18 +41,18 @@ class BaseEntryFactory:
         hash = hashlib.sha1()
         hash.update(formatted_id.encode(cls.__ASCII_CHARACTER_ENCODING))
 
-        return formatted_id[:cls.__ID_MAX_LENGTH-length_to_hash] + \
-            hash.hexdigest()[:length_to_hash]
+        return formatted_id[:cls.__ID_MAX_LENGTH - hash_length] + \
+               hash.hexdigest()[:hash_length]
 
     @classmethod
     def _format_display_name(cls, source_name):
-        return cls.__format_and_normalize_str(r'[^a-zA-Z0-9_\- ]+',
-                                              source_name)
+        return cls.__normalize_string(r'[^\w\- ]+', source_name)
 
     @classmethod
-    def __format_and_normalize_str(cls, regex_pattern, source_str):
-        formatted_str = re.sub(regex_pattern, '_',
-                               cls.__normalize_ascii_chars(source_str.strip()))
+    def __normalize_string(cls, regex_pattern, source_string):
+        formatted_str = re.sub(
+            regex_pattern, '_',
+            cls.__normalize_ascii_chars(source_string.strip()))
         return formatted_str
 
     @classmethod

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -26,16 +26,16 @@ class BaseEntryFactory:
 
     @classmethod
     def _format_id(cls, source_id):
-        formatted_id = cls.__format_and_normalize_str(
-            r'[^a-zA-Z0-9]+', source_id)
+        formatted_id = cls.__format_and_normalize_str(r'[^a-zA-Z0-9]+',
+                                                      source_id)
 
         return formatted_id[:cls.__ID_MAX_LENGTH] if \
             len(formatted_id) > cls.__ID_MAX_LENGTH else formatted_id
 
     @classmethod
     def _format_id_with_hashing(cls, source_id, length_to_hash):
-        formatted_id = cls.__format_and_normalize_str(
-            r'[^a-zA-Z0-9]+', source_id)
+        formatted_id = cls.__format_and_normalize_str(r'[^a-zA-Z0-9]+',
+                                                      source_id)
 
         if len(formatted_id) <= cls.__ID_MAX_LENGTH:
             return formatted_id
@@ -43,7 +43,6 @@ class BaseEntryFactory:
         hash = hashlib.sha1()
         hash.update(formatted_id.encode(cls.__ASCII_CHARACTER_ENCODING))
 
-        # Replace the length with part of the hashed string.
         return formatted_id[:cls.__ID_MAX_LENGTH-length_to_hash] + \
             hash.hexdigest()[:length_to_hash]
 
@@ -54,9 +53,9 @@ class BaseEntryFactory:
 
     @classmethod
     def __format_and_normalize_str(cls, regex_pattern, source_str):
-        formatted_id = re.sub(regex_pattern, '_',
-                              cls.__normalize_ascii_chars(source_str.strip()))
-        return formatted_id
+        formatted_str = re.sub(regex_pattern, '_',
+                               cls.__normalize_ascii_chars(source_str.strip()))
+        return formatted_str
 
     @classmethod
     def __normalize_ascii_chars(cls, source_string):

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -42,7 +42,7 @@ class BaseEntryFactory:
         hash.update(formatted_id.encode(cls.__ASCII_CHARACTER_ENCODING))
 
         return formatted_id[:cls.__ID_MAX_LENGTH - hash_length] + \
-               hash.hexdigest()[:hash_length]
+            hash.hexdigest()[:hash_length]
 
     @classmethod
     def _format_display_name(cls, source_name):

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import re
 import unicodedata
 import six
@@ -21,19 +22,41 @@ import six
 
 class BaseEntryFactory:
     __ASCII_CHARACTER_ENCODING = 'ASCII'
+    __ID_MAX_LENGTH = 64
 
     @classmethod
     def _format_id(cls, source_id):
-        formatted_id = re.sub(r'[^a-zA-Z0-9]+', '_',
-                              cls.__normalize_ascii_chars(source_id.strip()))
-        return formatted_id[:64] if len(formatted_id) > 64 else formatted_id
+        formatted_id = cls.__format_and_normalize_str(
+            r'[^a-zA-Z0-9]+', source_id)
+
+        return formatted_id[:cls.__ID_MAX_LENGTH] if \
+            len(formatted_id) > cls.__ID_MAX_LENGTH else formatted_id
+
+    @classmethod
+    def _format_id_with_hashing(cls, source_id, length_to_hash):
+        formatted_id = cls.__format_and_normalize_str(
+            r'[^a-zA-Z0-9]+', source_id)
+
+        if len(formatted_id) <= cls.__ID_MAX_LENGTH:
+            return formatted_id
+
+        hash = hashlib.sha1()
+        hash.update(formatted_id.encode(cls.__ASCII_CHARACTER_ENCODING))
+
+        # Replace the length with part of the hashed string.
+        return formatted_id[:cls.__ID_MAX_LENGTH-length_to_hash] + \
+            hash.hexdigest()[:length_to_hash]
 
     @classmethod
     def _format_display_name(cls, source_name):
-        formatted_name = re.sub(
-            r'[^a-zA-Z0-9_\- ]+', '_',
-            cls.__normalize_ascii_chars(source_name).strip())
-        return formatted_name
+        return cls.__format_and_normalize_str(r'[^a-zA-Z0-9_\- ]+',
+                                              source_name)
+
+    @classmethod
+    def __format_and_normalize_str(cls, regex_pattern, source_str):
+        formatted_id = re.sub(regex_pattern, '_',
+                              cls.__normalize_ascii_chars(source_str.strip()))
+        return formatted_id
 
     @classmethod
     def __normalize_ascii_chars(cls, source_string):

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -32,7 +32,8 @@ class BaseEntryFactoryTestCase(unittest.TestCase):
 
         expected_str = 'organization_warehouse7192ecb2_personsc3a8d512_business_7074c286'
 
-        formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(long_str, 8)
+        formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(
+            long_str, 8)
         self.assertEqual(expected_str, formatted_id)
 
     def test_format_display_name_should_normalize_non_compliant_name(self):

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -26,6 +26,15 @@ class BaseEntryFactoryTestCase(unittest.TestCase):
         formatted_id = prepare.BaseEntryFactory._format_id(u'ã123 - b456  ')
         self.assertEqual('a123_b456', formatted_id)
 
+    def test_format_id_with_hashing_should_normalize_non_compliant_id(self):
+        long_str = 'organization_warehouse7192ecb2__personsc3a8d512_' \
+                   'business_area_and_segment_of_marketing'
+
+        expected_str = 'organization_warehouse7192ecb2_personsc3a8d512_business_7074c286'
+
+        formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(long_str, 8)
+        self.assertEqual(expected_str, formatted_id)
+
     def test_format_display_name_should_normalize_non_compliant_name(self):
         formatted_name = prepare.BaseEntryFactory._format_display_name(
             u'ã123 :?: b456  ')

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -30,7 +30,8 @@ class BaseEntryFactoryTestCase(unittest.TestCase):
         long_str = 'organization_warehouse7192ecb2__personsc3a8d512_' \
                    'business_area_and_segment_of_marketing'
 
-        expected_str = 'organization_warehouse7192ecb2_personsc3a8d512_business_7074c286'
+        expected_str = 'organization_warehouse7192ecb2_personsc3a8d512_' \
+                       'business_7074c286'
 
         formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(
             long_str, 8)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added a new method to the `base_entry_factory.py` class to enable formatting entry id with hashing.

**- How I did it**
Uses the `hashlib` lib.

**- How to verify it**
Run hive connector in a hive server with tables that contain more than 64 chars.

**- Description for the changelog**
Hive table names can have 256 characters, so formatting the id with the existent strategy, by cutting to 64 chars (which is  the entry id limit) is not safe. In an environment with thousands of tables it's easy to have a name collision if we cut it that way.

This new strategy cuts the id and adds a hash created from the full id, that way we avoid collisions if the table name changes only in the final characters. The method receives the `length_to_hash` so the connector can hash it up to 64 chars.

