### PR TITLE
Add a new argument to _format_id_with_hashing to pass the regex pattern

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.6.5',
+    version='0.6.6',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -23,17 +23,36 @@ import unicodedata
 class BaseEntryFactory:
     __ASCII_CHARACTER_ENCODING = 'ASCII'
     __ID_MAX_LENGTH = 64
+    __ENTRY_ID_INVALID_CHARS_REGEX_PATTERN = r'[^a-zA-Z0-9]+'
+    __ENTRY_ID_HASH_LENGTH = 8
 
     @classmethod
     def _format_id(cls, source_id):
-        formatted_id = cls.__normalize_string(r'[^a-zA-Z0-9]+', source_id)
+        formatted_id = cls.__normalize_string(
+            cls.__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN, source_id)
 
         return formatted_id[:cls.__ID_MAX_LENGTH] if \
             len(formatted_id) > cls.__ID_MAX_LENGTH else formatted_id
 
     @classmethod
-    def _format_id_with_hashing(cls, source_id, hash_length):
-        formatted_id = cls.__normalize_string(r'[^a-zA-Z0-9]+', source_id)
+    def _format_id_with_hashing(
+            cls,
+            source_id,
+            regex_pattern=__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN,
+            hash_length=__ENTRY_ID_HASH_LENGTH):
+        """
+        Formats the source_id using the regex_pattern, and applies
+        a hashing strategy in the provided hash_length of the source_id to
+        generate a best effort unique ID.
+
+        :param source_id: value to be formatted.
+        :param regex_pattern: pattern used to replace invalid characters.
+        :param hash_length: length to be used for hashing
+         the ending of the ID.
+
+        :return: The formatted ID.
+        """
+        formatted_id = cls.__normalize_string(regex_pattern, source_id)
 
         if len(formatted_id) <= cls.__ID_MAX_LENGTH:
             return formatted_id

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -22,14 +22,14 @@ import unicodedata
 
 class BaseEntryFactory:
     __ASCII_CHARACTER_ENCODING = 'ASCII'
+    __DEFAULT_ENTRY_ID_HASH_LENGTH = 8
+    __DEFAULT_ENTRY_ID_INVALID_CHARS_REGEX_PATTERN = r'[^a-zA-Z0-9]+'
     __ID_MAX_LENGTH = 64
-    __ENTRY_ID_INVALID_CHARS_REGEX_PATTERN = r'[^a-zA-Z0-9]+'
-    __ENTRY_ID_HASH_LENGTH = 8
 
     @classmethod
     def _format_id(cls, source_id):
         formatted_id = cls.__normalize_string(
-            cls.__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN, source_id)
+            cls.__DEFAULT_ENTRY_ID_INVALID_CHARS_REGEX_PATTERN, source_id)
 
         return formatted_id[:cls.__ID_MAX_LENGTH] if \
             len(formatted_id) > cls.__ID_MAX_LENGTH else formatted_id
@@ -38,12 +38,12 @@ class BaseEntryFactory:
     def _format_id_with_hashing(
             cls,
             source_id,
-            regex_pattern=__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN,
-            hash_length=__ENTRY_ID_HASH_LENGTH):
+            regex_pattern=__DEFAULT_ENTRY_ID_INVALID_CHARS_REGEX_PATTERN,
+            hash_length=__DEFAULT_ENTRY_ID_HASH_LENGTH):
         """
-        Formats the source_id using the regex_pattern, and applies
-        a hashing strategy in the provided hash_length of the source_id to
-        generate a best effort unique ID.
+        Normalizes the source_id using the regex_pattern, and optionally
+        applies a hashing strategy (considering the provided hash_length)
+        over the source_id to generate a unique ID on a best-effort basis.
 
         :param source_id: value to be formatted.
         :param regex_pattern: pattern used to replace invalid characters.

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_entry_factory_test.py
@@ -34,7 +34,19 @@ class BaseEntryFactoryTestCase(unittest.TestCase):
                        'business_7074c286'
 
         formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(
-            long_str, 8)
+            long_str, hash_length=8)
+        self.assertEqual(expected_str, formatted_id)
+
+    def test_format_id_with_provided_pattern_should_normalize_non_compliant_id(  # noqa: E501
+            self):
+        long_str = 'organization__warehouse7192ecb2__personsc3a8d512_' \
+                   'business_area_and_segment_of_marketing'
+
+        expected_str = 'organization__warehouse7192ecb2_' \
+                       '_personsc3a8d512_businesa4f7e655'
+
+        formatted_id = prepare.BaseEntryFactory._format_id_with_hashing(
+            long_str, regex_pattern=r'[^a-zA-Z0-9_]+')
         self.assertEqual(expected_str, formatted_id)
 
     def test_format_display_name_should_normalize_non_compliant_name(self):


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added a new argument to `_format_id_with_hashing` to pass the regex pattern.

**- How I did it**
Added a new argument to `_format_id_with_hashing` to pass the regex pattern.

**- How to verify it**
Use the `_format_id_with_hashing` and pass the regex pattern.

**- Description for the changelog**
Some connectors might use a different pattern to format the id, so this should be open for extension. Having an argument in the method enable this, and let each connector take the decision.

In order to not impact existent connectors, we use a default value.

