### PR TITLE
Improve exception handling of upsert_entries to skip upsert_tags logic

### DIFF
--- a/google-datacatalog-connectors-commons/setup.py
+++ b/google-datacatalog-connectors-commons/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-connectors-commons',
-    version='0.6.6',
+    version='0.6.7',
     author='Google LLC',
     description='Common resources for Data Catalog connectors',
     packages=setuptools.find_packages(where='./src'),

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -115,6 +115,5 @@ class DataCatalogMetadataIngestor:
                         entry, assembled_entry_data.tags, managed_tag_template)
             except (exceptions.FailedPrecondition,
                     exceptions.PermissionDenied):
-                logging.warning(
-                    'Entry ignored, error on upsert_entry:',
-                    exc_info=True)
+                logging.warning('Entry ignored, error on upsert_entry:',
+                                exc_info=True)

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -91,22 +91,29 @@ class DataCatalogMetadataIngestor:
 
             entry_id = assembled_entry_data.entry_id
             new_entry = assembled_entry_data.entry
-            entry = self.__datacatalog_facade.upsert_entry(
-                entry_group_name, entry_id, new_entry)
 
-            logging.info('')
-            logging.info('Starting the upsert tags step')
-            self.__datacatalog_facade.upsert_tags(entry,
-                                                  assembled_entry_data.tags)
-            if config and 'delete_tags' in config:
-                delete_tags = config['delete_tags']
+            try:
+                entry = self.__datacatalog_facade.upsert_entry(
+                    entry_group_name, entry_id, new_entry)
+
                 logging.info('')
-                logging.info('Starting the delete tags step')
-                # If not specified uses the entry group id to find
-                # what tag templates should have their tags deleted.
-                managed_tag_template = delete_tags.get('managed_tag_template')
-                if not managed_tag_template:
-                    managed_tag_template = self.__entry_group_id
+                logging.info('Starting the upsert tags step')
+                self.__datacatalog_facade.upsert_tags(entry,
+                                                      assembled_entry_data.tags)
+                if config and 'delete_tags' in config:
+                    delete_tags = config['delete_tags']
+                    logging.info('')
+                    logging.info('Starting the delete tags step')
+                    # If not specified uses the entry group id to find
+                    # what tag templates should have their tags deleted.
+                    managed_tag_template = delete_tags.get('managed_tag_template')
+                    if not managed_tag_template:
+                        managed_tag_template = self.__entry_group_id
 
-                self.__datacatalog_facade.delete_tags(
-                    entry, assembled_entry_data.tags, managed_tag_template)
+                    self.__datacatalog_facade.delete_tags(
+                        entry, assembled_entry_data.tags, managed_tag_template)
+            except (exceptions.FailedPrecondition,
+                    exceptions.PermissionDenied):
+                logging.warning(
+                    'Entry ignored, unhandled error on upsert_entry:',
+                    exc_info=True)

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -98,15 +98,16 @@ class DataCatalogMetadataIngestor:
 
                 logging.info('')
                 logging.info('Starting the upsert tags step')
-                self.__datacatalog_facade.upsert_tags(entry,
-                                                      assembled_entry_data.tags)
+                self.__datacatalog_facade.upsert_tags(
+                    entry, assembled_entry_data.tags)
                 if config and 'delete_tags' in config:
                     delete_tags = config['delete_tags']
                     logging.info('')
                     logging.info('Starting the delete tags step')
                     # If not specified uses the entry group id to find
                     # what tag templates should have their tags deleted.
-                    managed_tag_template = delete_tags.get('managed_tag_template')
+                    managed_tag_template = delete_tags.get(
+                        'managed_tag_template')
                     if not managed_tag_template:
                         managed_tag_template = self.__entry_group_id
 

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor.py
@@ -116,5 +116,5 @@ class DataCatalogMetadataIngestor:
             except (exceptions.FailedPrecondition,
                     exceptions.PermissionDenied):
                 logging.warning(
-                    'Entry ignored, unhandled error on upsert_entry:',
+                    'Entry ignored, error on upsert_entry:',
                     exc_info=True)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -63,7 +63,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         datacatalog_client = self.__datacatalog_client
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
 
-    def test_create_entry_should_return_original_on_permission_denied(self):
+    def test_create_entry_should_raise_on_permission_denied(self):
         datacatalog_client = self.__datacatalog_client
         datacatalog_client.create_entry.side_effect = \
             exceptions.PermissionDenied('Permission denied')
@@ -72,11 +72,11 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
             'type', 'system', 'display_name', 'name', 'description',
             'linked_resource', 11, 22)
 
-        result = self.__datacatalog_facade.create_entry(
-            'entry_group_name', 'entry_id', entry)
+        self.assertRaises(exceptions.PermissionDenied,
+                          self.__datacatalog_facade.create_entry,
+                          'entry_group_name', 'entry_id', entry)
 
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
-        self.assertEqual(entry, result)
 
     def test_get_entry_should_succeed(self):
         self.__datacatalog_facade.get_entry('entry_name')
@@ -105,7 +105,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
 
-    def test_upsert_entry_nonexistent_on_failed_precondition_should_not_raise(
+    def test_upsert_entry_nonexistent_on_failed_precondition_should_raise(
             self):
 
         datacatalog_client = self.__datacatalog_client
@@ -119,8 +119,9 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
             'type', 'system', 'display_name', 'name', 'description',
             'linked_resource', 11, 22)
 
-        self.__datacatalog_facade.upsert_entry('entry_group_name', 'entry_id',
-                                               entry)
+        self.assertRaises(exceptions.FailedPrecondition,
+                          self.__datacatalog_facade.upsert_entry,
+                          'entry_group_name', 'entry_id', entry)
 
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
         self.assertEqual(1, datacatalog_client.create_entry.call_count)
@@ -326,7 +327,7 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
         datacatalog_client.update_entry.assert_called_with(entry=entry_2,
                                                            update_mask=None)
 
-    def test_upsert_entry_should_return_original_on_failed_precondition(self):
+    def test_upsert_entry_should_raise_on_failed_precondition(self):
         entry_1 = utils.Utils.create_entry_user_defined_type(
             'type', 'system', 'display_name', 'name', 'description',
             'linked_resource_1', 11, 22)
@@ -340,12 +341,12 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
             'type', 'system', 'display_name', 'name', 'description',
             'linked_resource_2', 11, 22)
 
-        result = self.__datacatalog_facade.upsert_entry(
-            'entry_group_name', 'entry_id', entry_2)
+        self.assertRaises(exceptions.FailedPrecondition,
+                          self.__datacatalog_facade.upsert_entry,
+                          'entry_group_name', 'entry_id', entry_2)
 
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
         self.assertEqual(1, datacatalog_client.update_entry.call_count)
-        self.assertEqual(entry_1, result)
 
     def test_upsert_entry_unchanged_should_not_update(self):
         entry = utils.Utils.create_entry_user_defined_type(

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
@@ -54,7 +54,8 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
 
-    def test_ingest_metadata_on_upsert_entry_failed_precondition_should_not_raise(self):  # noqa:E501
+    def test_ingest_metadata_on_upsert_entry_failed_precondition_should_not_raise(  # noqa:E501
+            self):
         entries = utils \
             .Utils.create_assembled_entries_user_defined_types()
 
@@ -67,7 +68,8 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
 
-    def test_ingest_metadata_on_upsert_entry_permission_denied_should_not_raise(self):  # noqa:E501
+    def test_ingest_metadata_on_upsert_entry_permission_denied_should_not_raise(  # noqa:E501
+            self):
         entries = utils \
             .Utils.create_assembled_entries_user_defined_types()
 

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/ingest/datacatalog_metadata_ingestor_test.py
@@ -54,6 +54,32 @@ class DataCatalogMetadataIngestorTestCase(unittest.TestCase):
         self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
         self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
 
+    def test_ingest_metadata_on_upsert_entry_failed_precondition_should_not_raise(self):  # noqa:E501
+        entries = utils \
+            .Utils.create_assembled_entries_user_defined_types()
+
+        datacatalog_facade = self.__datacatalog_facade
+        datacatalog_facade.upsert_entry.side_effect = \
+            exceptions.FailedPrecondition('Failed precondition')
+
+        self.__metadata_ingestor.ingest_metadata(entries, {})
+
+        self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
+        self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
+
+    def test_ingest_metadata_on_upsert_entry_permission_denied_should_not_raise(self):  # noqa:E501
+        entries = utils \
+            .Utils.create_assembled_entries_user_defined_types()
+
+        datacatalog_facade = self.__datacatalog_facade
+        datacatalog_facade.upsert_entry.side_effect = \
+            exceptions.PermissionDenied('Permission denied')
+
+        self.__metadata_ingestor.ingest_metadata(entries, {})
+
+        self.assertEqual(1, datacatalog_facade.create_entry_group.call_count)
+        self.assertEqual(2, datacatalog_facade.upsert_entry.call_count)
+
     def test_ingest_metadata_with_delete_tags_managed_template_config_should_succeed(  # noqa:E501
             self):
         entries = utils \


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Improved exception handling of `upsert_entries` method to skip `upsert_tags` logic.

**- How I did it**
Moved the exception handling to the `__ingest_entries` logic.

**- How to verify it**
Run a connector where any entry is in the `exceptions.FailedPrecondition` state. (usually this happens when you create entries in the same entry group multiple times or with a large amount of entries 5k+ 10k+). The entry and the create tags logic should be skipped.

**- Description for the changelog**
When a `exceptions.FailedPrecondition` was raised on `upsert_entries` the exception was caught and not raised, so the ingest_entries logic would attempt to create the entry tags.

The connector should skip the entry and also the tags creation in this scenario, so the exception handling needs to be done in the `__ingest_entries` logic.

