### PR TITLE
Added trim logic to commons normalize string method.

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -96,7 +96,7 @@ class BaseEntryFactory:
 
     @classmethod
     def _format_display_name(cls, source_name):
-        return cls.__normalize_string(r'[^\w\- ]+', source_name)
+        return cls.__normalize_string(r'[^\w\- ]+', source_name).strip()
 
     @classmethod
     def __normalize_string(cls, regex_pattern, source_string):

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -96,14 +96,14 @@ class BaseEntryFactory:
 
     @classmethod
     def _format_display_name(cls, source_name):
-        return cls.__normalize_string(r'[^\w\- ]+', source_name).strip()
+        return cls.__normalize_string(r'[^\w\- ]+', source_name)
 
     @classmethod
     def __normalize_string(cls, regex_pattern, source_string):
         formatted_str = re.sub(
             regex_pattern, '_',
             cls.__normalize_ascii_chars(source_string.strip()))
-        return formatted_str
+        return formatted_str.strip()
 
     @classmethod
     def __normalize_ascii_chars(cls, source_string):

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_entry_factory.py
@@ -103,6 +103,11 @@ class BaseEntryFactory:
         formatted_str = re.sub(
             regex_pattern, '_',
             cls.__normalize_ascii_chars(source_string.strip()))
+
+        # The __normalize_ascii_chars logic may replace a non ascii
+        # char with space at the end of the string, so we need to do
+        # an additional strip() to make sure it is removed from the
+        # final normalized string.
         return formatted_str.strip()
 
     @classmethod


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added the `strip()` logic to the `__normalize_string` method.  

We already have a `strip()` call to the `__normalize_ascii_chars`, as it can be seen on the `__normalize_string` method:
```
    @classmethod
    def __normalize_string(cls, regex_pattern, source_string):
        formatted_str = re.sub(
            regex_pattern, '_',
            cls.__normalize_ascii_chars(source_string.strip()))
        return formatted_str.strip()
```

But running the looker connector I was able to generate display names that contain spaces at the end of the string. So this change adds a `strip()` call to the `formatted_str` return to make sure the formatted string won't have this extra space.

**- How to verify it**
Run the looker connector as it can be seen on #46. The error should not happen with this change, and entries should be successfully ingested.

**- Description for the changelog**
Fixes #46. 

