### PR TITLE
ADD helper class to extract region tags content

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
@@ -17,4 +17,4 @@
 from .values_comparable_object import ValuesComparableObject
 from .region_tag_helper import RegionTagHelper
 
-__all__ = ('ValuesComparableObject','RegionTagHelper')
+__all__ = ('ValuesComparableObject', 'RegionTagHelper')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .values_comparable_object import ValuesComparableObject
 from .region_tag_helper import RegionTagHelper
+from .values_comparable_object import ValuesComparableObject
 
-__all__ = ('ValuesComparableObject', 'RegionTagHelper')
+__all__ = ('RegionTagHelper', 'ValuesComparableObject')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/__init__.py
@@ -15,5 +15,6 @@
 # limitations under the License.
 
 from .values_comparable_object import ValuesComparableObject
+from .region_tag_helper import RegionTagHelper
 
-__all__ = ('ValuesComparableObject',)
+__all__ = ('ValuesComparableObject','RegionTagHelper')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -20,10 +20,10 @@ import re
 
 class RegionTagHelper:
     """
-    Regex pattern to split string into 3 groups:
+    Regex pattern to split a string into 3 groups:
 
     Group 1: [{REGION_TAG_NAME}_START]
-    Group 2: Content between START and END region tags
+    Group 2: Content between the START and END tags
     Group 3: [{REGION_TAG_NAME}_END]
     """
     __REGION_TAG_GROUP_REGEX = re.compile(
@@ -31,9 +31,9 @@ class RegionTagHelper:
         re.MULTILINE)
 
     @classmethod
-    def extract_content(cls, content_with_tags):
+    def extract_content(cls, string):
         """
-        Extract content inside defined START/END region tags.
+        Extracts the content between START and END region tags.
         """
         re_match = re.match(pattern=cls.__REGION_TAG_GROUP_REGEX,
                             string=content_with_tags)
@@ -41,9 +41,9 @@ class RegionTagHelper:
             region_tag_start, content_with_tags, region_tag_end, = \
                 re_match.groups()
             logging.debug(
-                'Region tags defined! START region tag: %s END region tag: %s',
+                'Region tags found! START tag: "%s" END tag: "%s"',
                 region_tag_start, region_tag_end)
             # Strip additional whitespaces
             return content_with_tags.strip()
         else:
-            logging.debug('No START/END region tags defined!')
+            logging.debug('No START/END region tags found!')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -19,7 +19,6 @@ import re
 
 
 class RegionTagHelper:
-
     """
     Regex pattern to split string into 3 groups:
 
@@ -28,20 +27,22 @@ class RegionTagHelper:
     Group 3: [{REGION_TAG_NAME}_END]
     """
     __REGION_TAG_GROUP_REGEX = re.compile(
-        r"^(\s*\[\S*_START\][^\S\r\n]*)((?s:.)*)(\s*\[\S*_END\]\s*)", re.MULTILINE)
+        r"^(\s*\[\S*_START\][^\S\r\n]*)((?s:.)*)(\s*\[\S*_END\]\s*)",
+        re.MULTILINE)
 
     @classmethod
-    def extract_content(cls,
-                        content_with_tags):
+    def extract_content(cls, content_with_tags):
         """
         Extract content inside defined START/END region tags.
         """
         re_match = re.match(pattern=cls.__REGION_TAG_GROUP_REGEX,
                             string=content_with_tags)
         if re_match:
-            region_tag_start, content_with_tags, region_tag_end, = re_match.groups()
-            logging.debug('Region tags defined! START region tag: %s END region tag: %s',
-                          region_tag_start, region_tag_end)
+            region_tag_start, content_with_tags, region_tag_end, = re_match.groups(
+            )
+            logging.debug(
+                'Region tags defined! START region tag: %s END region tag: %s',
+                region_tag_start, region_tag_end)
             # Strip additional whitespaces
             return content_with_tags.strip()
         else:

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -19,22 +19,19 @@ import re
 
 
 class RegionTagHelper:
-    """
-    Helper class with common logic to work with region tags like:
+    """Helper class with common logic to work with region tags such as:
     [GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START]
     ...
     [GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END]
 
     In the scenario there are multiple tags with the same name, the
-    logic will be applied only to the last tag.
+    logic will be applied only to the last one.
     """
-    """
-    Regex pattern to split a string into 3 groups:
 
-    Group 1: [{REGION_TAG_NAME}_START]
-    Group 2: Content between the START and END tags
-    Group 3: [{REGION_TAG_NAME}_END]
-    """
+    # Regex pattern to split a string into 3 groups:
+    # Group 1: [{REGION_TAG_NAME}_START]
+    # Group 2: Content between the START and END tags
+    # Group 3: [{REGION_TAG_NAME}_END]
     __REGION_TAG_GROUP_REGEX_TEMPLATE = \
         r'^(?s:.)*(?P<start_tag>\[{}_START\][^\S\r\n]*)' \
         r'(?P<tag_content>(?s:.)*)' \
@@ -43,7 +40,7 @@ class RegionTagHelper:
     @classmethod
     def extract_content(cls, tag_name, string):
         """
-        Extracts the content between START and END region_tag_name tags.
+        Extracts the content between START and END tags.
         """
 
         tag_group_regex = \

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -20,6 +20,16 @@ import re
 
 class RegionTagHelper:
     """
+    Helper class with common logic to work with region tags like:
+    [GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START]
+    ...
+    [GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END]
+
+    In the scenario there are multiple tags with the same name, the
+    logic will be applied only to the last tag.
+    """
+
+    """
     Regex pattern to split a string into 3 groups:
 
     Group 1: [{REGION_TAG_NAME}_START]
@@ -27,31 +37,30 @@ class RegionTagHelper:
     Group 3: [{REGION_TAG_NAME}_END]
     """
     __REGION_TAG_GROUP_REGEX_TEMPLATE = \
-        r'^(?s:.)*(?P<region_tag_start>\[{}_START\][^\S\r\n]*)' \
+        r'^(?s:.)*(?P<start_tag>\[{}_START\][^\S\r\n]*)' \
         r'(?P<tag_content>(?s:.)*)' \
-        r'(?P<region_tag_end>\s*\[{}_END\]\s*)$'
+        r'(?P<end_tag>\s*\[{}_END\]\s*)$'
 
     @classmethod
-    def extract_content(cls, region_tag_name, string):
+    def extract_content(cls, tag_name, string):
         """
         Extracts the content between START and END region_tag_name tags.
         """
 
-        region_tag_group_regex = \
+        tag_group_regex = \
             cls.__REGION_TAG_GROUP_REGEX_TEMPLATE.replace(
-                '{}', region_tag_name)
+                '{}', tag_name)
 
-        region_tag_group_regex_compiled = re.compile(region_tag_group_regex,
-                                                     re.MULTILINE)
+        compiled_regex = re.compile(tag_group_regex, re.MULTILINE)
 
-        re_match = re.match(pattern=region_tag_group_regex_compiled,
+        re_match = re.match(pattern=compiled_regex,
                             string=string)
         if re_match:
-            region_tag_start, tag_content, region_tag_end, = \
+            start_tag, tag_content, end_tag, = \
                 re_match.group(
-                    'region_tag_start', 'tag_content', 'region_tag_end')
+                    'start_tag', 'tag_content', 'end_tag')
             logging.debug('Region tags found! START tag: "%s" END tag: "%s"',
-                          region_tag_start, region_tag_end)
+                          start_tag, end_tag)
             # Strip additional whitespaces
             return tag_content.strip()
 

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -26,24 +26,33 @@ class RegionTagHelper:
     Group 2: Content between the START and END tags
     Group 3: [{REGION_TAG_NAME}_END]
     """
-    __REGION_TAG_GROUP_REGEX = re.compile(
-        r"^(\s*\[\S*_START\][^\S\r\n]*)((?s:.)*)(\s*\[\S*_END\]\s*)",
-        re.MULTILINE)
+    __REGION_TAG_GROUP_REGEX_TEMPLATE = \
+        r'^(?s:.)*(?P<region_tag_start>\[{}_START\][^\S\r\n]*)' \
+        r'(?P<tag_content>(?s:.)*)' \
+        r'(?P<region_tag_end>\s*\[{}_END\]\s*)$'
 
     @classmethod
-    def extract_content(cls, string):
+    def extract_content(cls, region_tag_name, string):
         """
-        Extracts the content between START and END region tags.
+        Extracts the content between START and END region_tag_name tags.
         """
-        re_match = re.match(pattern=cls.__REGION_TAG_GROUP_REGEX,
-                            string=content_with_tags)
+
+        region_tag_group_regex = \
+            cls.__REGION_TAG_GROUP_REGEX_TEMPLATE.replace(
+                '{}', region_tag_name)
+
+        region_tag_group_regex_compiled = re.compile(region_tag_group_regex,
+                                                     re.MULTILINE)
+
+        re_match = re.match(pattern=region_tag_group_regex_compiled,
+                            string=string)
         if re_match:
-            region_tag_start, content_with_tags, region_tag_end, = \
-                re_match.groups()
-            logging.debug(
-                'Region tags found! START tag: "%s" END tag: "%s"',
-                region_tag_start, region_tag_end)
+            region_tag_start, tag_content, region_tag_end, = \
+                re_match.group(
+                    'region_tag_start', 'tag_content', 'region_tag_end')
+            logging.debug('Region tags found! START tag: "%s" END tag: "%s"',
+                          region_tag_start, region_tag_end)
             # Strip additional whitespaces
-            return content_with_tags.strip()
-        else:
-            logging.debug('No START/END region tags found!')
+            return tag_content.strip()
+
+        logging.debug('No START/END region tags found!')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -28,7 +28,6 @@ class RegionTagHelper:
     In the scenario there are multiple tags with the same name, the
     logic will be applied only to the last tag.
     """
-
     """
     Regex pattern to split a string into 3 groups:
 
@@ -53,8 +52,7 @@ class RegionTagHelper:
 
         compiled_regex = re.compile(tag_group_regex, re.MULTILINE)
 
-        re_match = re.match(pattern=compiled_regex,
-                            string=string)
+        re_match = re.match(pattern=compiled_regex, string=string)
         if re_match:
             start_tag, tag_content, end_tag, = \
                 re_match.group(

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+
+
+class RegionTagHelper:
+
+    """
+    Regex pattern to split string into 3 groups:
+
+    Group 1: [{REGION_TAG_NAME}_START]
+    Group 2: Content between START and END region tags
+    Group 3: [{REGION_TAG_NAME}_END]
+    """
+    __REGION_TAG_GROUP_REGEX = re.compile(
+        r"^(\s*\[\S*_START\][^\S\r\n]*)((?s:.)*)(\s*\[\S*_END\]\s*)", re.MULTILINE)
+
+    @classmethod
+    def extract_content(cls,
+                        content_with_tags):
+        """
+        Extract content inside defined START/END region tags.
+        """
+        re_match = re.match(pattern=cls.__REGION_TAG_GROUP_REGEX,
+                            string=content_with_tags)
+        if re_match:
+            region_tag_start, content_with_tags, region_tag_end, = re_match.groups()
+            logging.debug('Region tags defined! START region tag: %s END region tag: %s',
+                          region_tag_start, region_tag_end)
+            # Strip additional whitespaces
+            return content_with_tags.strip()
+        else:
+            logging.debug('No START/END region tags defined!')

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/utils/region_tag_helper.py
@@ -38,8 +38,8 @@ class RegionTagHelper:
         re_match = re.match(pattern=cls.__REGION_TAG_GROUP_REGEX,
                             string=content_with_tags)
         if re_match:
-            region_tag_start, content_with_tags, region_tag_end, = re_match.groups(
-            )
+            region_tag_start, content_with_tags, region_tag_end, = \
+                re_match.groups()
             logging.debug(
                 'Region tags defined! START region tag: %s END region tag: %s',
                 region_tag_start, region_tag_end)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -39,7 +39,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
         content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
             expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
-        extracted_tag_content = region_tag_helper.extract_content(content_string)
+        extracted_tag_content = region_tag_helper.extract_content(
+            content_string)
 
         self.assertEqual(extracted_tag_content, expected_tag_content)
 
@@ -61,7 +62,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
         content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
             expected_tag_content + '\n'
 
-        extracted_tag_content = region_tag_helper.extract_content(content_string)
+        extracted_tag_content = region_tag_helper.extract_content(
+            content_string)
 
         self.assertIsNone(extracted_tag_content)
 
@@ -82,7 +84,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
 
         content_string = expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
-        extracted_tag_content = region_tag_helper.extract_content(content_string)
+        extracted_tag_content = region_tag_helper.extract_content(
+            content_string)
 
         self.assertIsNone(extracted_tag_content)
 
@@ -101,7 +104,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
                 type: 'int'
         '''.strip()
 
-        extracted_tag_content = region_tag_helper.extract_content(expected_tag_content)
+        extracted_tag_content = region_tag_helper.extract_content(
+            expected_tag_content)
 
         self.assertIsNone(extracted_tag_content)
 
@@ -123,6 +127,7 @@ class RegionTagHelperTestCase(unittest.TestCase):
         content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_STARX] \n' + \
             expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_ENX] \n'
 
-        extracted_tag_content = region_tag_helper.extract_content(content_string)
+        extracted_tag_content = region_tag_helper.extract_content(
+            content_string)
 
         self.assertIsNone(extracted_tag_content)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -42,9 +42,58 @@ class RegionTagHelperTestCase(unittest.TestCase):
             '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
-            content_string)
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
 
         self.assertEqual(extracted_tag_content, expected_tag_content)
+
+    def test_extract_multiple_tag_content_should_return_correct_content(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        tags_with_content = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        expected_tag_content_2 = '''
+        metadata_definition:
+          - name: 'sp_other_cloud'
+            purpose: 'This stored procedure run in another cloud.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        tags_with_content_2 = \
+            '[OTHER_CLOUD_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content_2 + \
+            '\n[OTHER_CLOUD_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        content_string = tags_with_content + '\n' + tags_with_content_2
+
+        extracted_tag_content = region_tag_helper.extract_content(
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
+
+        self.assertEqual(extracted_tag_content, expected_tag_content)
+
+        extracted_tag_content_2 = region_tag_helper.extract_content(
+            'OTHER_CLOUD_DATA_CATALOG_METADATA_DEFINITION', content_string)
+
+        self.assertEqual(extracted_tag_content_2, expected_tag_content_2)
 
     def test_extract_tag_content_no_end_region_tag_should_return_none(self):
         region_tag_helper = utils.RegionTagHelper()
@@ -66,7 +115,7 @@ class RegionTagHelperTestCase(unittest.TestCase):
             expected_tag_content + '\n'
 
         extracted_tag_content = region_tag_helper.extract_content(
-            content_string)
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
 
         self.assertIsNone(extracted_tag_content)
 
@@ -89,14 +138,14 @@ class RegionTagHelperTestCase(unittest.TestCase):
             '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
-            content_string)
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
 
         self.assertIsNone(extracted_tag_content)
 
     def test_extract_tag_content_no_region_tags_should_return_none(self):
         region_tag_helper = utils.RegionTagHelper()
 
-        expected_tag_content = '''
+        content_string = '''
         metadata_definition:
           - name: 'sp_calculateOrder'
             purpose: 'This stored procedure will calculate orders.'
@@ -109,7 +158,7 @@ class RegionTagHelperTestCase(unittest.TestCase):
         '''.strip()
 
         extracted_tag_content = region_tag_helper.extract_content(
-            expected_tag_content)
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
 
         self.assertIsNone(extracted_tag_content)
 
@@ -134,6 +183,6 @@ class RegionTagHelperTestCase(unittest.TestCase):
             '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_ENX] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
-            content_string)
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
 
         self.assertIsNone(extracted_tag_content)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.datacatalog_connectors.commons import utils
+
+
+class RegionTagHelperTestCase(unittest.TestCase):
+
+    def test_extract_tag_content_should_return_correct_content(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        extracted_tag_content = region_tag_helper.extract_content(content_string)
+
+        self.assertEqual(extracted_tag_content, expected_tag_content)
+
+    def test_extract_tag_content_no_end_region_tag_should_return_none(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content + '\n'
+
+        extracted_tag_content = region_tag_helper.extract_content(content_string)
+
+        self.assertIsNone(extracted_tag_content)
+
+    def test_extract_tag_content_no_start_region_tag_should_return_none(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        content_string = expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        extracted_tag_content = region_tag_helper.extract_content(content_string)
+
+        self.assertIsNone(extracted_tag_content)
+
+    def test_extract_tag_content_no_region_tags_should_return_none(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        extracted_tag_content = region_tag_helper.extract_content(expected_tag_content)
+
+        self.assertIsNone(extracted_tag_content)
+
+    def test_extract_tag_content_invalid_region_tags_should_return_none(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_STARX] \n' + \
+            expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_ENX] \n'
+
+        extracted_tag_content = region_tag_helper.extract_content(content_string)
+
+        self.assertIsNone(extracted_tag_content)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -36,8 +36,10 @@ class RegionTagHelperTestCase(unittest.TestCase):
                 type: 'int'
         '''.strip()
 
-        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
-            expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+        content_string = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
             content_string)
@@ -59,7 +61,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
                 type: 'int'
         '''.strip()
 
-        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+        content_string = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
             expected_tag_content + '\n'
 
         extracted_tag_content = region_tag_helper.extract_content(
@@ -82,7 +85,8 @@ class RegionTagHelperTestCase(unittest.TestCase):
                 type: 'int'
         '''.strip()
 
-        content_string = expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+        content_string = expected_tag_content + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
             content_string)
@@ -124,8 +128,10 @@ class RegionTagHelperTestCase(unittest.TestCase):
                 type: 'int'
         '''.strip()
 
-        content_string = '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_STARX] \n' + \
-            expected_tag_content + '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_ENX] \n'
+        content_string = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_STARX] \n' + \
+            expected_tag_content + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_ENX] \n'
 
         extracted_tag_content = region_tag_helper.extract_content(
             content_string)

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/utils/region_tag_helper_test.py
@@ -95,6 +95,50 @@ class RegionTagHelperTestCase(unittest.TestCase):
 
         self.assertEqual(extracted_tag_content_2, expected_tag_content_2)
 
+    def test_extract_repeated_tag_should_return_last_content(self):
+        region_tag_helper = utils.RegionTagHelper()
+
+        expected_tag_content = '''
+        metadata_definition:
+          - name: 'sp_calculateOrder'
+            purpose: 'This stored procedure will calculate orders.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        tags_with_content = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        expected_tag_content_2 = '''
+        metadata_definition:
+          - name: 'sp_other_cloud'
+            purpose: 'This stored procedure run in another cloud.'
+            inputs:
+              - name: 'in1'
+                type: 'string'
+            outputs:
+              - name: 'out1'
+                type: 'int'
+        '''.strip()
+
+        tags_with_content_2 = \
+            '[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_START] \n' + \
+            expected_tag_content_2 + \
+            '\n[GOOGLE_DATA_CATALOG_METADATA_DEFINITION_END] \n'
+
+        content_string = tags_with_content + '\n' + tags_with_content_2
+
+        extracted_tag_content = region_tag_helper.extract_content(
+            'GOOGLE_DATA_CATALOG_METADATA_DEFINITION', content_string)
+
+        self.assertEqual(extracted_tag_content, expected_tag_content_2)
+
     def test_extract_tag_content_no_end_region_tag_should_return_none(self):
         region_tag_helper = utils.RegionTagHelper()
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Created a helper class to extract the content of region tags. The name "region  tags" is inspired on the code samples region tags.

**- How I did it**
Used a regex expression to extract the content group.

**- How to verify it**
Run the new unit tests with this PR.

**- Description for the changelog**
Creates a common class needed to implement the feature request: https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/issues/63

