### PR TITLE
Add optional Tag Template Field attributes

### DIFF
--- a/google-datacatalog-connectors-commons/.coveragerc
+++ b/google-datacatalog-connectors-commons/.coveragerc
@@ -1,4 +1,6 @@
 # .coveragerc to control coverage.py
 [run]
+omit =
+    */__init__.py
 source =
     src

--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_template_factory.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/prepare/base_tag_template_factory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,13 @@ from google.cloud import datacatalog
 class BaseTagTemplateFactory:
 
     @classmethod
-    def _add_enum_type_field(cls, tag_template, field_id, values,
-                             display_name):
+    def _add_enum_type_field(cls,
+                             tag_template,
+                             field_id,
+                             values,
+                             display_name,
+                             is_required=False,
+                             order=None):
 
         field = datacatalog.TagTemplateField()
         for value in values:
@@ -30,13 +35,24 @@ class BaseTagTemplateFactory:
             field.type.enum_type.allowed_values.append(enum_value)
 
         field.display_name = display_name
+        field.is_required = is_required
+        field.order = order
+
         tag_template.fields[field_id] = field
 
     @classmethod
-    def _add_primitive_type_field(cls, tag_template, field_id, field_type,
-                                  display_name):
+    def _add_primitive_type_field(cls,
+                                  tag_template,
+                                  field_id,
+                                  field_type,
+                                  display_name,
+                                  is_required=False,
+                                  order=None):
 
         field = datacatalog.TagTemplateField()
         field.type.primitive_type = field_type
         field.display_name = display_name
+        field.is_required = is_required
+        field.order = order
+
         tag_template.fields[field_id] = field

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_template_factory_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/prepare/base_tag_template_factory_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
-# coding=utf-8
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +16,9 @@
 
 import unittest
 
-from google.datacatalog_connectors.commons import prepare
-
 from google.cloud import datacatalog
+
+from google.datacatalog_connectors.commons import prepare
 
 
 class BaseTagFactoryTestCase(unittest.TestCase):
@@ -35,6 +34,28 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         self.assertEqual(2, len(field.type.enum_type.allowed_values))
         self.assertEqual('Enum field', field.display_name)
 
+    def test_add_enum_type_field_should_optionally_set_is_required(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_enum_type_field(tag_template,
+                                                            'enum-field',
+                                                            ['VALUE_1'],
+                                                            'Enum field',
+                                                            is_required=True)
+
+        field = tag_template.fields['enum-field']
+        self.assertEqual(True, field.is_required)
+
+    def test_add_enum_type_field_should_optionally_set_order(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_enum_type_field(tag_template,
+                                                            'enum-field',
+                                                            ['VALUE_1'],
+                                                            'Enum field',
+                                                            order=10)
+
+        field = tag_template.fields['enum-field']
+        self.assertEqual(10, field.order)
+
     def test_add_primitive_type_field_should_set_elementary_properties(self):
         tag_template = datacatalog.TagTemplate()
         prepare.BaseTagTemplateFactory._add_primitive_type_field(
@@ -47,3 +68,27 @@ class BaseTagFactoryTestCase(unittest.TestCase):
         self.assertEqual(datacatalog.FieldType.PrimitiveType.STRING,
                          field.type.primitive_type)
         self.assertEqual('String field', field.display_name)
+
+    def test_add_primitive_type_field_should_optionally_set_is_required(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_primitive_type_field(
+            tag_template,
+            'string-field',
+            datacatalog.FieldType.PrimitiveType.STRING,
+            'String field',
+            is_required=True)
+
+        field = tag_template.fields['string-field']
+        self.assertEqual(True, field.is_required)
+
+    def test_add_primitive_type_field_should_optionally_set_order(self):
+        tag_template = datacatalog.TagTemplate()
+        prepare.BaseTagTemplateFactory._add_primitive_type_field(
+            tag_template,
+            'string-field',
+            datacatalog.FieldType.PrimitiveType.STRING,
+            'String field',
+            order=10)
+
+        field = tag_template.fields['string-field']
+        self.assertEqual(10, field.order)


### PR DESCRIPTION
**- What I did**
Added code to handle the optional `is_required` and `order` Tag Template Field attributes.

**- How I did it**
Added new optional input args to the `prepare.BaseTagTemplateFactory` public methods and used them to set the above-mentioned field attributes.

**- How to verify it**
Run the unit tests and, preferably, some dependent connector in an integrated environment to make sure there are no breaking changes.

**- Description for the changelog**
Added code to handle the optional `is_required` and `order` Tag Template Field attributes.

Closes #32.