### PR TITLE
Add support for getting entries by linked resources

### DIFF
--- a/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
+++ b/google-datacatalog-connectors-commons/src/google/datacatalog_connectors/commons/datacatalog_facade.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,6 +65,17 @@ class DataCatalogFacade:
         :return: An Entry object if it exists.
         """
         return self.__datacatalog.get_entry(name=name)
+
+    def lookup_entry(self, linked_resource):
+        """Get an Entry by target resource name.
+
+        :param linked_resource: The full name of the resource the Data Catalog
+            Entry represents.
+        :return: An Entry object if it exists.
+        """
+        request = datacatalog.LookupEntryRequest()
+        request.linked_resource = linked_resource
+        return self.__datacatalog.lookup_entry(request=request)
 
     def update_entry(self, entry):
         """Updates an Entry.

--- a/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
+++ b/google-datacatalog-connectors-commons/tests/google/datacatalog_connectors/commons/datacatalog_facade_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +83,26 @@ class DataCatalogFacadeTestCase(unittest.TestCase):
 
         datacatalog_client = self.__datacatalog_client
         self.assertEqual(1, datacatalog_client.get_entry.call_count)
+
+    def test_lookup_entry_should_return_datacatalog_client_result(self):
+        fake_entry = datacatalog.Entry()
+        fake_entry.linked_resource = 'linked_resource'
+
+        datacatalog_client = self.__datacatalog_client
+        datacatalog_client.lookup_entry.return_value = fake_entry
+
+        entry = self.__datacatalog_facade.lookup_entry('linked_resource')
+
+        self.assertEqual(fake_entry, entry)
+
+    def test_lookup_entry_should_fulfill_linked_resource_request_field(self):
+        self.__datacatalog_facade.lookup_entry('linked_resource')
+
+        fake_request = datacatalog.LookupEntryRequest()
+        fake_request.linked_resource = 'linked_resource'
+        datacatalog_client = self.__datacatalog_client
+        datacatalog_client.lookup_entry.assert_called_once_with(
+            request=fake_request)
 
     def test_update_entry_should_succeed(self):
         self.__datacatalog_facade.update_entry({})


### PR DESCRIPTION
**- What I did**
Added support for getting entries by their linked resources.

**- How I did it**
Added the `DataCatalogFacade.lookup_entry()` method, which provides support for getting entries by their linked resources.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added support for getting entries by their linked resources.

This PR is part of the effort to deliver https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/70.